### PR TITLE
feat: add GitHub-style navigation progress bar and repo loading skeleton

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { AppNavbar } from "@/components/layout/navbar";
 import { GlobalChatProvider } from "@/components/shared/global-chat-provider";
 import { GlobalChatPanel } from "@/components/shared/global-chat-panel";
+import { NavigationProgress } from "@/components/shared/navigation-progress";
 import { getServerSession } from "@/lib/auth";
 import { type GhostTabState } from "@/lib/chat-store";
 import { ColorThemeProvider } from "@/components/theme/theme-provider";
@@ -28,6 +29,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 				<ColorThemeProvider>
 					<CodeThemeProvider>
 						<GitHubLinkInterceptor>
+							<NavigationProgress />
 							<div className="flex flex-col h-dvh overflow-y-auto lg:overflow-hidden">
 								<AppNavbar session={session} />
 								<div className="mt-10 lg:h-[calc(100dvh-var(--spacing)*10)] flex flex-col px-2 sm:px-4 pt-2 lg:overflow-auto">

--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/loading.tsx
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/loading.tsx
@@ -1,0 +1,17 @@
+export default function RepoLoading() {
+	return (
+		<div className="animate-pulse space-y-4">
+			<div className="h-4 w-48 rounded bg-muted" />
+			<div className="space-y-3">
+				<div className="h-3 w-full rounded bg-muted/60" />
+				<div className="h-3 w-5/6 rounded bg-muted/60" />
+				<div className="h-3 w-4/6 rounded bg-muted/60" />
+			</div>
+			<div className="space-y-3 pt-2">
+				<div className="h-3 w-full rounded bg-muted/60" />
+				<div className="h-3 w-3/4 rounded bg-muted/60" />
+				<div className="h-3 w-5/6 rounded bg-muted/60" />
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -171,6 +171,44 @@ body {
 	background: var(--selection-bg);
 }
 
+/* Navigation progress bar (GitHub-style) */
+@keyframes progress-bar-loading {
+	0% {
+		width: 0%;
+	}
+	20% {
+		width: 30%;
+	}
+	50% {
+		width: 60%;
+	}
+	80% {
+		width: 80%;
+	}
+	100% {
+		width: 90%;
+	}
+}
+
+@keyframes progress-bar-complete {
+	from {
+		width: 90%;
+		opacity: 1;
+	}
+	to {
+		width: 100%;
+		opacity: 0;
+	}
+}
+
+.animate-progress-bar {
+	animation: progress-bar-loading 8s cubic-bezier(0.2, 0.5, 0.3, 1) forwards;
+}
+
+.animate-progress-complete {
+	animation: progress-bar-complete 300ms ease-out forwards;
+}
+
 /* Hide scrollbar but keep scrolling */
 .no-scrollbar {
 	-ms-overflow-style: none;

--- a/apps/web/src/components/shared/navigation-progress.tsx
+++ b/apps/web/src/components/shared/navigation-progress.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+
+export function NavigationProgress() {
+	const pathname = usePathname();
+	const [state, setState] = useState<"idle" | "loading" | "completing">(
+		"idle",
+	);
+	const prevPathname = useRef(pathname);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+	// Detect navigation start: listen for link clicks
+	useEffect(() => {
+		function handleClick(e: MouseEvent) {
+			const anchor = (e.target as HTMLElement).closest("a");
+			if (
+				!anchor ||
+				!anchor.href ||
+				anchor.target === "_blank" ||
+				e.metaKey ||
+				e.ctrlKey ||
+				e.shiftKey
+			)
+				return;
+
+			try {
+				const url = new URL(anchor.href, window.location.origin);
+				// Only internal navigations
+				if (url.origin !== window.location.origin) return;
+				// Skip same-page links
+				if (url.pathname === window.location.pathname) return;
+
+				setState("loading");
+			} catch {
+				// ignore invalid URLs
+			}
+		}
+
+		document.addEventListener("click", handleClick, { capture: true });
+		return () =>
+			document.removeEventListener("click", handleClick, {
+				capture: true,
+			});
+	}, []);
+
+	// Detect navigation end: pathname changed
+	useEffect(() => {
+		if (pathname !== prevPathname.current) {
+			prevPathname.current = pathname;
+			setState("completing");
+			clearTimeout(timeoutRef.current);
+			timeoutRef.current = setTimeout(() => setState("idle"), 300);
+		}
+		return () => clearTimeout(timeoutRef.current);
+	}, [pathname]);
+
+	if (state === "idle") return null;
+
+	return (
+		<div className="fixed top-0 left-0 right-0 z-[9999] h-0.5">
+			<div
+				className={
+					state === "loading"
+						? "h-full bg-primary origin-left animate-progress-bar"
+						: "h-full bg-primary origin-left animate-progress-complete"
+				}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
Show a top-of-page progress bar during route transitions for immediate visual feedback, and add a Suspense loading skeleton for repo pages so the layout stays interactive while page content streams in.