### PR TITLE
fix: suppress hydration mismatch for timezone-dependent dashboard content

### DIFF
--- a/apps/web/src/components/dashboard/dashboard-content.tsx
+++ b/apps/web/src/components/dashboard/dashboard-content.tsx
@@ -80,10 +80,10 @@ export function DashboardContent({
 		<div className="flex flex-col flex-1 min-h-0 w-full">
 			{/* Header */}
 			<div className="shrink-0 pb-3">
-				<h1 className="text-sm font-medium">
+				<h1 className="text-sm font-medium" suppressHydrationWarning>
 					{greeting}, {user.name || user.login}
 				</h1>
-				<p className="text-[11px] text-muted-foreground font-mono">
+				<p className="text-[11px] text-muted-foreground font-mono" suppressHydrationWarning>
 					{today}
 				</p>
 			</div>


### PR DESCRIPTION
The greeting and date strings are computed using `new Date()` which produces different results on the server vs client when timezones differ. Add `suppressHydrationWarning` so React silently accepts the mismatch and the client value wins after hydration.