### PR TITLE
Fix GitHub profile URL using wrong user ID

### DIFF
--- a/apps/web/src/components/layout/navbar.tsx
+++ b/apps/web/src/components/layout/navbar.tsx
@@ -111,7 +111,7 @@ export function AppNavbar({ session }: AppNavbarProps) {
 													detail: "search",
 												},
 											),
-										)
+									)
 									}
 									className="text-[11px] gap-2 h-7"
 								>
@@ -119,11 +119,11 @@ export function AppNavbar({ session }: AppNavbarProps) {
 									Search repos
 								</DropdownMenuItem>
 
-								{session.user.name && (
+								{session.githubUser.login && (
 									<DropdownMenuItem
 										onClick={() =>
 											window.open(
-												`https://github.com/${session.user.name}`,
+												`https://github.com/${session.githubUser.login}`,
 												"_blank",
 											)
 										}


### PR DESCRIPTION
## Bug Description

The GitHub profile menu button in the navbar was using the wrong user identifier, causing broken profile links.

### Problem

The dropdown menu item for "GitHub profile" was using `session.user.name` to construct the GitHub URL:

```tsx
window.open(`https://github.com/${session.user.name}`, "_blank")
```

This is incorrect because `user.name` is the display name (e.g., "John Doe"), not the GitHub username/login. The resulting URL would be `https://github.com/John Doe` which returns a 404.

### Solution

Changed to use `session.githubUser.login` which is the actual GitHub username returned from the GitHub API:

```tsx
window.open(`https://github.com/${session.githubUser.login}`, "_blank")
```

Also updated the condition to check `session.githubUser.login` instead of `session.user.name` for consistency.

### Files Changed

- `apps/web/src/components/layout/navbar.tsx`

---

This fix ensures users are correctly redirected to their actual GitHub profile page.