### PR TITLE
fix: use payload.size for correct push event commit count

### DIFF
--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/activity/page.tsx
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/activity/page.tsx
@@ -29,6 +29,7 @@ export default async function ActivityPage({
 						action?: string;
 						ref?: string;
 						ref_type?: string;
+						size?: number;
 						commits?: { sha: string; message: string }[];
 						pull_request?: { number: number; title: string };
 						issue?: { number: number; title: string };

--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/overview-actions.ts
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/overview-actions.ts
@@ -46,6 +46,7 @@ export interface OverviewRepoEvent {
 		action?: string;
 		ref?: string;
 		ref_type?: string;
+		size?: number;
 		commits?: { sha: string; message: string }[];
 		pull_request?: { number: number; title: string };
 		issue?: { number: number; title: string };

--- a/apps/web/src/components/repo/repo-activity-view.tsx
+++ b/apps/web/src/components/repo/repo-activity-view.tsx
@@ -29,6 +29,7 @@ interface RepoEvent {
 		action?: string;
 		ref?: string;
 		ref_type?: string;
+		size?: number;
 		commits?: { sha: string; message: string }[];
 		pull_request?: { number: number; title: string };
 		issue?: { number: number; title: string };
@@ -47,15 +48,19 @@ function getEventDescription(
 	switch (event.type) {
 		case "PushEvent": {
 			const branch = p?.ref?.replace("refs/heads/", "") ?? "";
-			const commitCount = p?.commits?.length ?? 0;
+			const commitCount = p?.size ?? p?.commits?.length ?? 0;
 			const firstCommit = p?.commits?.[0];
 			const firstMsg = firstCommit?.message?.split("\n")[0] ?? "";
 			const commitHref =
 				commitCount === 1 && firstCommit?.sha
 					? `${base}/commits/${firstCommit.sha.slice(0, 7)}`
 					: `${base}/commits`;
+			const verb =
+				commitCount > 0
+					? `pushed ${commitCount} commit${commitCount !== 1 ? "s" : ""} to ${branch}`
+					: `pushed to ${branch}`;
 			return {
-				verb: `pushed ${commitCount} commit${commitCount !== 1 ? "s" : ""} to ${branch}`,
+				verb,
 				detail: firstMsg,
 				href: commitHref,
 			};

--- a/apps/web/src/components/repo/repo-overview.tsx
+++ b/apps/web/src/components/repo/repo-overview.tsx
@@ -211,7 +211,7 @@ function getEventDescription(event: RepoEvent): {
 	switch (event.type) {
 		case "PushEvent": {
 			const branch = p?.ref?.replace("refs/heads/", "") ?? "";
-			const commitCount = p?.commits?.length ?? 0;
+			const commitCount = p?.size ?? p?.commits?.length ?? 0;
 			const firstCommit = p?.commits?.[0];
 			const firstMsg = firstCommit?.message?.split("\n")[0] ?? "";
 			const commitHref =
@@ -220,8 +220,12 @@ function getEventDescription(event: RepoEvent): {
 					: base
 						? `${base}/commits`
 						: null;
+			const verb =
+				commitCount > 0
+					? `pushed ${commitCount} commit${commitCount !== 1 ? "s" : ""} to ${branch}`
+					: `pushed to ${branch}`;
 			return {
-				verb: `pushed ${commitCount} commit${commitCount !== 1 ? "s" : ""} to ${branch}`,
+				verb,
 				detail: firstMsg,
 				href: commitHref,
 			};
@@ -551,6 +555,7 @@ interface RepoEvent {
 		action?: string;
 		ref?: string;
 		ref_type?: string;
+		size?: number;
 		commits?: { sha: string; message: string }[];
 		pull_request?: { number: number; title: string };
 		issue?: { number: number; title: string };


### PR DESCRIPTION
The GitHub Events API caps the commits array at 20 entries and may return it empty, but always provides payload.size with the true count. Use size as the primary source and fall back gracefully to "pushed to {branch}" when the count is still zero.