### PR TITLE
fix: message box max-height

### DIFF
--- a/apps/web/src/components/shared/markdown-editor.tsx
+++ b/apps/web/src/components/shared/markdown-editor.tsx
@@ -360,7 +360,10 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
 				</div>
 
 				{/* Rich text editor */}
-				<div style={{ minHeight }} className="resize-y overflow-auto">
+				<div
+					style={{ minHeight, maxHeight: 400 }}
+					className="resize-y overflow-auto"
+				>
 					<EditorContent editor={editor} />
 				</div>
 			</div>


### PR DESCRIPTION
Right now there isn't a max-height, so pasting code would make the box take up the entire screen and looks really bad.

This adds a max-height to make it look reasonable.

## Before:

<img width="1054" height="1882" alt="CleanShot 2026-02-22 at 14 26 50@2x" src="https://github.com/user-attachments/assets/4944e1f5-810f-4bc9-8b11-9a06980dd640" />


## After:

<img width="1036" height="1804" alt="CleanShot 2026-02-22 at 14 27 17@2x" src="https://github.com/user-attachments/assets/2a7dc686-236f-488c-9194-5d8c8565df9f" />

