### PR TITLE
feat: add co-author display and expandable commit messages

### DIFF
--- a/apps/web/src/components/pr/pr-conversation.tsx
+++ b/apps/web/src/components/pr/pr-conversation.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { GitCommitHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TimeAgo } from "@/components/ui/time-ago";
+import { parseCoAuthors, getInitials } from "@/lib/commit-utils";
 import { MarkdownRenderer } from "@/components/shared/markdown-renderer";
 import { CollapsibleReviewCard } from "./collapsible-review-card";
 import { BotActivityGroup } from "./bot-activity-group";
@@ -445,6 +446,7 @@ function CommitGroup({ commits }: { commits: CommitEntry[] }) {
 		<div className="rounded-lg border border-border/60 overflow-hidden">
 			{commits.map((commit, i) => {
 				const firstLine = commit.message.split("\n")[0];
+				const coAuthors = parseCoAuthors(commit.message);
 				return (
 					<div
 						key={commit.sha}
@@ -454,19 +456,33 @@ function CommitGroup({ commits }: { commits: CommitEntry[] }) {
 						)}
 					>
 						<GitCommitHorizontal className="w-3.5 h-3.5 text-muted-foreground/30 shrink-0" />
-						{commit.user ? (
-							<Link href={`/users/${commit.user.login}`}>
-								<Image
-									src={commit.user.avatar_url}
-									alt={commit.user.login}
-									width={16}
-									height={16}
-									className="rounded-full shrink-0"
-								/>
-							</Link>
-						) : (
-							<div className="w-4 h-4 rounded-full bg-muted-foreground shrink-0" />
-						)}
+						<div className="flex items-center -space-x-1 shrink-0">
+							{commit.user ? (
+								<Link href={`/users/${commit.user.login}`} className="relative z-10">
+									<Image
+										src={commit.user.avatar_url}
+										alt={commit.user.login}
+										width={16}
+										height={16}
+										className="rounded-full border border-background"
+									/>
+								</Link>
+							) : (
+								<div className="w-4 h-4 rounded-full bg-muted-foreground border border-background relative z-10 shrink-0" />
+							)}
+							{coAuthors.slice(0, 2).map((ca, ci) => (
+								<div
+									key={ca.email}
+									className="rounded-full bg-muted border border-background flex items-center justify-center shrink-0 relative"
+									style={{ width: 16, height: 16, zIndex: 9 - ci }}
+									title={`${ca.name} <${ca.email}>`}
+								>
+									<span className="text-[7px] font-medium text-muted-foreground leading-none">
+										{getInitials(ca.name)}
+									</span>
+								</div>
+							))}
+						</div>
 						<span className="text-xs text-foreground/80 truncate flex-1 min-w-0">
 							{firstLine}
 						</span>

--- a/apps/web/src/components/repo/commit-detail.tsx
+++ b/apps/web/src/components/repo/commit-detail.tsx
@@ -7,6 +7,7 @@ import { parseDiffPatch, type DiffLine, type DiffSegment } from "@/lib/github-ut
 import type { SyntaxToken } from "@/lib/shiki";
 import { cn } from "@/lib/utils";
 import { TimeAgo } from "@/components/ui/time-ago";
+import { parseCoAuthors, getCommitBody, getInitials } from "@/lib/commit-utils";
 import {
 	File,
 	FilePlus2,
@@ -130,10 +131,10 @@ export function CommitDetail({ owner, repo, commit, highlightData }: CommitDetai
 		setTimeout(() => setCopiedSha(false), 2000);
 	};
 
-	// Parse the commit message: first line is title, rest is body
-	const messageLines = commit.commit.message.split("\n");
-	const title = messageLines[0];
-	const body = messageLines.slice(1).join("\n").trim();
+	// Parse the commit message: first line is title, rest is body (excluding co-author trailers)
+	const title = commit.commit.message.split("\n")[0];
+	const body = getCommitBody(commit.commit.message);
+	const coAuthors = parseCoAuthors(commit.commit.message);
 
 	const authorDate = commit.commit.author?.date;
 	const authorName = commit.author?.login ?? commit.commit.author?.name ?? "Unknown";
@@ -205,6 +206,31 @@ export function CommitDetail({ owner, repo, commit, highlightData }: CommitDetai
 							</span>
 						)}
 					</div>
+
+					{/* Co-authors */}
+					{coAuthors.length > 0 && (
+						<>
+							<span className="text-muted-foreground/30">|</span>
+							<div className="flex items-center gap-1.5">
+								{coAuthors.map((ca) => (
+									<div
+										key={ca.email}
+										className="flex items-center gap-1"
+										title={`${ca.name} <${ca.email}>`}
+									>
+										<div className="rounded-full bg-muted flex items-center justify-center shrink-0 h-[18px] w-[18px]">
+											<span className="text-[7px] font-medium text-muted-foreground leading-none">
+												{getInitials(ca.name)}
+											</span>
+										</div>
+										<span className="text-xs text-foreground/70">
+											{ca.name}
+										</span>
+									</div>
+								))}
+							</div>
+						</>
+					)}
 
 					<span className="text-muted-foreground/30">|</span>
 

--- a/apps/web/src/lib/commit-utils.ts
+++ b/apps/web/src/lib/commit-utils.ts
@@ -1,0 +1,48 @@
+export interface CoAuthor {
+	name: string;
+	email: string;
+}
+
+const CO_AUTHOR_GLOBAL_RE = /^Co-authored-by:\s*(.+?)\s*<([^>]+)>/gim;
+const CO_AUTHOR_LINE_RE = /^Co-authored-by:\s*/i;
+
+/**
+ * Parse `Co-authored-by: Name <email>` trailers from a commit message.
+ * Deduplicates by email (case-insensitive).
+ */
+export function parseCoAuthors(message: string): CoAuthor[] {
+	const seen = new Set<string>();
+	const result: CoAuthor[] = [];
+	for (const match of message.matchAll(CO_AUTHOR_GLOBAL_RE)) {
+		const email = match[2].toLowerCase();
+		if (seen.has(email)) continue;
+		seen.add(email);
+		result.push({ name: match[1], email });
+	}
+	return result;
+}
+
+/**
+ * Extract the body of a commit message (everything after the first line),
+ * excluding Co-authored-by trailers.
+ */
+export function getCommitBody(message: string): string {
+	const lines = message.split("\n");
+	const bodyLines = lines.slice(1);
+	return bodyLines
+		.filter((line) => !CO_AUTHOR_LINE_RE.test(line))
+		.join("\n")
+		.trim();
+}
+
+/**
+ * Get initials from a name, e.g. "John Doe" -> "JD".
+ * Falls back to first two characters if single word.
+ */
+export function getInitials(name: string): string {
+	const parts = name.trim().split(/\s+/);
+	if (parts.length >= 2) {
+		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	}
+	return name.slice(0, 2).toUpperCase();
+}


### PR DESCRIPTION
Parse Co-authored-by trailers to show initials badges alongside commit authors, and add inline expand/collapse for multi-line commit messages across the commits list, commit detail, and PR conversation views.