### PR TITLE
feat: commit sheet

### DIFF
--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="sheet-overlay"
+			className={cn(
+				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/25 dark:bg-black/70 backdrop-blur-[2px]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+interface SheetContentProps extends React.ComponentProps<typeof DialogPrimitive.Content> {
+	side?: "left" | "right" | "top" | "bottom";
+	showCloseButton?: boolean;
+}
+
+function SheetContent({
+	className,
+	children,
+	side = "right",
+	showCloseButton = true,
+	...props
+}: SheetContentProps) {
+	const sideStyles = {
+		right: "inset-y-0 right-0 h-full w-3/4 sm:max-w-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+		left: "inset-y-0 left-0 h-full w-3/4 sm:max-w-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+		top: "inset-x-0 top-0 w-full data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+		bottom: "inset-x-0 bottom-0 w-full data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+	};
+
+	return (
+		<SheetPortal>
+			<SheetOverlay />
+			<DialogPrimitive.Content
+				data-slot="sheet-content"
+				className={cn(
+					"fixed z-50 flex flex-col bg-background border-l border-border shadow-lg duration-300",
+					sideStyles[side],
+					className,
+				)}
+				{...props}
+			>
+				<DialogPrimitive.Title className="hidden sr-only">
+					{props.title}
+				</DialogPrimitive.Title>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary cursor-pointer">
+						<XIcon className="h-4 w-4" />
+						<span className="sr-only">Close</span>
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Content>
+		</SheetPortal>
+	);
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="sheet-header"
+			className={cn(
+				"flex flex-col gap-2 px-6 py-4 border-b border-border",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="sheet-footer"
+			className={cn(
+				"flex flex-col-reverse gap-2 px-6 py-4 border-t border-border sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="sheet-title"
+			className={cn("text-lg font-semibold text-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="sheet-description"
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetOverlay,
+	SheetPortal,
+	SheetTitle,
+	SheetTrigger,
+};

--- a/apps/web/src/hooks/use-is-mobile.ts
+++ b/apps/web/src/hooks/use-is-mobile.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+	const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
+
+	useEffect(() => {
+		const checkMobile = () => {
+			setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+		};
+
+		checkMobile();
+
+		const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+		mql.addEventListener("change", checkMobile);
+
+		return () => mql.removeEventListener("change", checkMobile);
+	}, []);
+
+	return isMobile;
+}


### PR DESCRIPTION
Often when checking commits of a repo, you want to skim through and view multiple commits at a time.
This PR makes viewing a commit on desktop open a sheet to allow you to easily view them, rather than being redirected to a dedicated page every time.

https://github.com/user-attachments/assets/d40ea93f-2293-437c-a561-3005297ac815

This PR also improves the commit details UI to always show the file name. Previously the file-name would truncate over the file-path, but this PR forces file-names to be visible over file-paths.

For example:
<img width="668" height="680" alt="CleanShot 2026-02-23 at 09 02 56@2x" src="https://github.com/user-attachments/assets/8ac9800c-80c8-4d57-bd18-85d33d1bf472" />

The old version:
<img width="762" height="724" alt="CleanShot 2026-02-23 at 09 03 52@2x" src="https://github.com/user-attachments/assets/3ad59b32-6d0d-461f-8102-6ddd6079be3c" />
