### PR TITLE
fix: breadcrumb position

### DIFF
--- a/apps/web/src/components/repo/repo-layout-wrapper.tsx
+++ b/apps/web/src/components/repo/repo-layout-wrapper.tsx
@@ -201,7 +201,7 @@ export function RepoLayoutWrapper({
 				}
 			>
 				<div
-					className={`hidden lg:flex px-2 pt-3 pb-1 ${collapsed ? "visible" : "invisible"}`}
+					className={`hidden lg:flex pl-7 pr-2 pt-3 pb-1 ${collapsed ? "visible" : "invisible"}`}
 				>
 					<RepoBreadcrumb
 						owner={owner}


### PR DESCRIPTION
Fix breadcrumb alignment.

## Before
<img width="532" height="362" alt="CleanShot 2026-02-24 at 10 30 52@2x" src="https://github.com/user-attachments/assets/63c4b7a0-bf3e-40e9-b225-93e0d59296b6" />

## After
<img width="602" height="586" alt="CleanShot 2026-02-24 at 10 32 00@2x" src="https://github.com/user-attachments/assets/80d163c7-2ce5-4487-80b9-777797203d73" />
