### PR TITLE
fix: batch normalize() calls in clearTextHighlights to prevent tab fr…

### DIFF
--- a/apps/web/src/components/repo/code-viewer-client.tsx
+++ b/apps/web/src/components/repo/code-viewer-client.tsx
@@ -45,13 +45,16 @@ interface SearchMatch {
 
 function clearTextHighlights(container: Element) {
 	const marks = container.querySelectorAll("mark.search-text-match");
+	if (marks.length === 0) return;
+	const parents = new Set<Node>();
 	marks.forEach((mark) => {
 		const parent = mark.parentNode;
 		if (parent) {
+			parents.add(parent);
 			parent.replaceChild(document.createTextNode(mark.textContent || ""), mark);
-			parent.normalize();
 		}
 	});
+	parents.forEach((parent) => (parent as Element).normalize());
 }
 
 function highlightTextInLine(lineEl: Element, query: string, caseSensitive: boolean) {


### PR DESCRIPTION
…eeze
fixes #41

Before: tab froze when deleting final character in "find in file" command
After: deleting final character works find due to batched normalizing of highlighting.