### PR TITLE
fix: prevent message send on Enter key during composition in AI chat

### DIFF
--- a/apps/web/src/components/shared/ai-chat.tsx
+++ b/apps/web/src/components/shared/ai-chat.tsx
@@ -1240,7 +1240,7 @@ export function AIChat({
 				return;
 			}
 		}
-		if (e.key === "Enter" && !e.shiftKey) {
+		if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
 			e.preventDefault();
 			handleSend();
 		}


### PR DESCRIPTION
This pull request introduces a small but important improvement to the `AIChat` component. The change ensures that pressing Enter to send a message does not trigger while the user is composing text (such as when using an IME for East Asian languages), preventing accidental message sends.

* Prevented sending messages on Enter keypress while text composition is active by checking `e.nativeEvent.isComposing` in `AIChat`.

Before:

https://github.com/user-attachments/assets/b2114c8b-fafa-4b6e-8383-cdf7c493a096

After:

https://github.com/user-attachments/assets/d8d96c44-9aeb-417e-b36e-fe0fadaafc01

