### PR TITLE
fix: only enable OAuth proxy on Vercel deployments

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -35,10 +35,10 @@ export const auth = betterAuth({
 			},
 		}),
 		admin(),
-		oAuthProxy({
-			productionURL: "https://www.better-hub.com",
-		}),
 		patSignIn(),
+		...(process.env.VERCEL
+			? [oAuthProxy({ productionURL: "https://www.better-hub.com" })]
+			: []),
 	],
 	user: {
 		additionalFields: {


### PR DESCRIPTION
contributors use different OAuth clients, so the OAuth Proxy should be disabled in the local environment.

- Closes #60