### PR TITLE
fix: adjust padding in loading and person detail components

### DIFF
--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/people/[username]/loading.tsx
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/people/[username]/loading.tsx
@@ -2,7 +2,7 @@ export default function PersonDetailLoading() {
 	return (
 		<div className="animate-pulse">
 			{/* Profile header */}
-			<div className="flex items-start gap-4 mb-6">
+			<div className="flex items-start gap-4 my-6">
 				<div className="h-16 w-16 rounded-full bg-muted/40 shrink-0" />
 				<div className="space-y-2 flex-1">
 					<div className="h-5 w-36 rounded bg-muted/50" />

--- a/apps/web/src/components/people/person-detail.tsx
+++ b/apps/web/src/components/people/person-detail.tsx
@@ -248,7 +248,7 @@ export function PersonDetail({ owner, repo, user, activity, weeklyData }: Person
 	return (
 		<div className="flex flex-col flex-1 min-h-0">
 			{/* Header */}
-			<div className="shrink-0 space-y-4 pb-4">
+			<div className="shrink-0 space-y-4 py-4">
 				{/* Avatar + info */}
 				<div className="flex items-start gap-4">
 					<Image


### PR DESCRIPTION
closes #83 

Just evened out the padding on the `/repo/people/[username]` page.

Before:
<img width="458" height="372" alt="CleanShot 2026-02-25 at 18 18 23@2x" src="https://github.com/user-attachments/assets/f2651a89-6aaf-470b-8515-20688439eeb2" />


After:
<img width="476" height="356" alt="CleanShot 2026-02-25 at 18 17 29@2x" src="https://github.com/user-attachments/assets/ff2a3e4c-b189-4fa5-b771-76b11ae2ad5d" />
