### PR TITLE
Fix: Decode URL-encoded paths in file-content API

### DIFF
--- a/apps/web/src/app/api/file-content/route.ts
+++ b/apps/web/src/app/api/file-content/route.ts
@@ -22,7 +22,11 @@ export async function GET(request: NextRequest) {
 		);
 	}
 
-	const data = await getFileContent(owner, repo, path, ref);
+	// Decode the path to handle URL-encoded characters from Next.js routes
+	// e.g., %5Bowner%5D -> [owner], %28app%29 -> (app)
+	const decodedPath = decodeURIComponent(path);
+
+	const data = await getFileContent(owner, repo, decodedPath, ref);
 	if (!data) {
 		return NextResponse.json({ error: "File not found" }, { status: 404 });
 	}


### PR DESCRIPTION
## Summary
The `/api/file-content` endpoint was returning 404 for valid files when the path contained URL-encoded characters (like `%5B%5D` for `[]`, `%28%29` for `()`).

## Problem
When browsing deeply nested files in repos with Next.js-style route group or dynamic segment folder names (e.g., `src/app/(app)/[owner]/page.tsx`), the URL contains encoded characters like `%28app%29` and `%5Bowner%5D`. 

The GitHub API internally URL-encodes the path parameter. When we pass pre-encoded paths, it results in double-encoding, causing the file lookup to fail.

## Fix
Added `decodeURIComponent()` in the API route to decode the path before passing to `getFileContent()`.

### Before
```
path=apps/web/src/app/%28app%29/%5Bowner%5D/page.tsx
→ GitHub API receives: apps/web/src/app/%28app%29/%5Bowner%5D/page.tsx
→ Double-encoded → 404
```

### After
```
path=apps/web/src/app/%28app%29/%5Bowner%5D/page.tsx
→ decodeURIComponent → apps/web/src/app/(app)/[owner]/page.tsx
→ GitHub API encodes properly → 200
```

## Testing
- ✅ `GET /api/file-content?owner=better-auth&repo=better-hub&path=apps/web/src/app/(app)/[owner]/page.tsx&ref=main` now returns file content
- ✅ Regular paths without special characters continue to work

Fixes #100

Fixes #100