### PR TITLE
fix: validate GitHub PR/issue numeric IDs

### DIFF
--- a/apps/web/src/lib/github-utils.ts
+++ b/apps/web/src/lib/github-utils.ts
@@ -173,7 +173,7 @@ function parsePositiveInt(value: string | undefined): number | null {
 	if (!value) return null;
 	if (!/^\d+$/.test(value)) return null;
 	const parsed = Number.parseInt(value, 10);
-	return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+	return parsed > 0 && parsed <= Number.MAX_SAFE_INTEGER ? parsed : null;
 }
 
 export function parseGitHubUrl(htmlUrl: string): ParsedGitHubUrl | null {


### PR DESCRIPTION
The issue was in GitHub URL parsing for PR/issue links.

anything after pull/ or issues/ was taken as  valid.  like  bad links like .../pull/not-a-number were treated as valid and  and produced broken app routes like /owner/repo/pulls/NaN. 