### PR TITLE
fix: convert Buffer to Uint8Array for Response body compatibility

### DIFF
--- a/apps/web/src/app/api/extension-download/route.ts
+++ b/apps/web/src/app/api/extension-download/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
 	try {
 		const buffer = await readFile(filePath);
 
-		return new Response(buffer, {
+		return new Response(new Uint8Array(buffer), {
 			headers: {
 				"Content-Type": "application/zip",
 				"Content-Disposition": `attachment; filename="${fileName}"`,


### PR DESCRIPTION
## Summary
- Fix Vercel build error in `extension-download` API route
- `Buffer` is not assignable to `BodyInit` in newer TypeScript — wrap with `new Uint8Array()` to fix

## Test plan
- [ ] Verify Vercel build passes
- [ ] Test extension download endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)