### PR TITLE
fix: bypass link interceptor for external GitHub buttons

### DIFF
--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/layout.tsx
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/layout.tsx
@@ -69,6 +69,7 @@ function RepoErrorPage({ owner, repo, error }: { owner: string; repo: string; er
 			</div>
 			<a
 				href={githubUrl}
+				data-no-github-intercept
 				target="_blank"
 				rel="noopener noreferrer"
 				className="flex items-center gap-1.5 text-[11px] font-mono px-3 py-1.5 border border-border text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"

--- a/apps/web/src/app/(app)/users/[username]/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/page.tsx
@@ -26,6 +26,7 @@ function UnknownUserPage({ username }: { username: string }) {
 			</div>
 			<a
 				href={githubUrl}
+				data-no-github-intercept
 				target="_blank"
 				rel="noopener noreferrer"
 				className="flex items-center gap-1.5 text-[11px] font-mono px-3 py-1.5 border border-border text-muted-foreground hover:text-foreground hover:border-border transition-colors"

--- a/apps/web/src/components/security/advisory-detail.tsx
+++ b/apps/web/src/components/security/advisory-detail.tsx
@@ -436,6 +436,7 @@ export function AdvisoryDetail({
 					{/* View on GitHub */}
 					<a
 						href={advisory.htmlUrl}
+						data-no-github-intercept
 						target="_blank"
 						rel="noopener noreferrer"
 						className="flex items-center justify-center gap-2 w-full border border-border px-3 py-2 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"

--- a/apps/web/src/components/shared/github-link-interceptor.tsx
+++ b/apps/web/src/components/shared/github-link-interceptor.tsx
@@ -19,6 +19,7 @@ export function GitHubLinkInterceptor({ children }: { children: React.ReactNode 
 
 			const anchor = (e.target as HTMLElement).closest("a");
 			if (!anchor) return;
+			if (anchor.hasAttribute("data-no-github-intercept")) return;
 
 			const href = anchor.href;
 			if (!href) return;


### PR DESCRIPTION
## Summary

The "View on GitHub" button on error pages (restricted repo, unknown user, advisory detail) showed the right URL on hover but clicking it did nothing, or rather, it was getting swallowed by the internal link interceptor.

The app has a click handler that rewrites github.com links to internal routes. It had no way to opt out, so even buttons that were supposed to open real GitHub got caught by it. Right-click > open in new tab worked fine since that bypasses JS entirely.

The fix adds a `data-no-github-intercept` attribute to the interceptor. Any anchor with that attribute is left alone. Then the three affected buttons got that attribute added.

## Changes

- **`components/shared/github-link-interceptor.tsx`** — skip interception if anchor has `data-no-github-intercept`
- **`app/(app)/repos/[owner]/[repo]/layout.tsx`** — mark the error-state "View on GitHub" button
- **`app/(app)/users/[username]/page.tsx`** — same, on the unknown user page
- **`components/security/advisory-detail.tsx`** — same, on the advisory sidebar button

## Screenshot

<img width="786" height="471" alt="image" src="https://github.com/user-attachments/assets/f0cfe0bf-369d-4166-95e0-9f8189bb4c21" />


## Test plan

- [ ] Hit a restricted or private repo error state, click "View on GitHub" -> opens GitHub in a new tab
- [ ] Visit an unknown/bot user page, same check
- [ ] Open any advisory detail, click "View on GitHub" in the sidebar -> opens GitHub
- [ ] Click any other github.com link in the app (repo name, PR author, etc.) -> still routes internally, nothing broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
