### PR TITLE
fix: timezone mismatch causing inconsistent greeting on dashboard

### DIFF
--- a/apps/web/src/components/dashboard/dashboard-content.tsx
+++ b/apps/web/src/components/dashboard/dashboard-content.tsx
@@ -80,13 +80,20 @@ export function DashboardContent({
 	activity,
 	trending,
 }: DashboardContentProps) {
-	const greeting = getGreeting();
-	const today = new Date().toLocaleDateString("en-US", {
-		weekday: "long",
-		month: "long",
-		day: "numeric",
-		year: "numeric",
-	});
+	const [greeting, setGreeting] = useState<string>("");
+	const [today, setToday] = useState<string>("");
+
+	useEffect(() => {
+		setGreeting(getGreeting());
+		setToday(
+			new Date().toLocaleDateString("en-US", {
+				weekday: "long",
+				month: "long",
+				day: "numeric",
+				year: "numeric",
+			}),
+		);
+	}, []);
 
 	const hasWork =
 		reviewRequests.items.length > 0 ||
@@ -114,7 +121,7 @@ export function DashboardContent({
 			{/* Header */}
 			<div className="shrink-0 pb-3">
 				<h1 className="text-sm font-medium" suppressHydrationWarning>
-					{greeting}, {user.name || user.login}
+					{greeting ? `${greeting}, ${user.name || user.login}` : `${user.name || user.login}`}
 				</h1>
 				<p
 					className="text-[11px] text-muted-foreground font-mono"


### PR DESCRIPTION
## Problem
On page refresh, the greeting and date on the dashboard page were inconsistent with subsequent client renders. This was caused by a **timezone mismatch** between the server (which generated the SSR HTML) and the client (which hydrated the page).

## Solution
Moved the `getGreeting()` call and date formatting into `useEffect`, ensuring these values are calculated only on the client side using the user's local timezone. This eliminates the hydration mismatch.

### Changes
- Added `useState` hooks for `greeting` and `today` with empty initial values
- Added `useEffect` to calculate greeting and date after component mounts (client-side)
- Updated the greeting display to handle the initial empty state gracefully

Fixes #133

Fixes #133