### PR TITLE
fix: clarify GitHub scope selection before OAuth connect

### DIFF
--- a/apps/web/src/components/login-button.tsx
+++ b/apps/web/src/components/login-button.tsx
@@ -196,6 +196,10 @@ export function LoginButton({ redirectTo }: { redirectTo?: string }) {
 		}
 		return initial;
 	});
+	const requiredCount = SCOPE_GROUPS.filter((group) => group.required).length;
+	const selectedCount = selected.size;
+	const optionalSelectedCount = Math.max(0, selectedCount - requiredCount);
+	const permissionLabel = selectedCount === 1 ? "permission" : "permissions";
 
 	function toggle(id: string) {
 		const group = SCOPE_GROUPS.find((g) => g.id === id);
@@ -254,12 +258,12 @@ export function LoginButton({ redirectTo }: { redirectTo?: string }) {
 				<>
 					{/* Scope picker — compact wrapped pills */}
 					<div>
-						<p className="text-[11px] font-mono uppercase tracking-wider text-foreground/40 mb-1.5">
-							Permissions
+						<p className="text-[11px] font-mono uppercase tracking-wider text-foreground/70 mb-1.5">
+							Choose GitHub access before connecting
 						</p>
-						<p className="text-[11px] text-foreground/30 mb-2.5">
-							Click to toggle optional permissions. Hover
-							the{" "}
+						<p className="text-[11px] text-foreground/45 mb-2.5">
+							Click any permission to include or remove
+							it. Hover the{" "}
 							<InfoIcon className="inline w-3 h-3 -mt-px" />{" "}
 							to learn why each is needed.
 						</p>
@@ -325,6 +329,32 @@ export function LoginButton({ redirectTo }: { redirectTo?: string }) {
 								);
 							})}
 						</div>
+						<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-foreground/40">
+							<span className="inline-flex items-center gap-1">
+								<LockIcon className="w-2.5 h-2.5" />
+								Required
+							</span>
+							<span className="inline-flex items-center gap-1">
+								<CheckIcon className="w-2.5 h-2.5" />
+								Selected optional
+							</span>
+						</div>
+						<div className="mt-3 space-y-1.5">
+							<div className="rounded-md border border-foreground/15 bg-foreground/[0.06] px-2.5 py-2">
+								<p className="text-[11px] text-foreground/70">
+									Requesting: {
+										requiredCount
+									}{" "}
+									required +{" "}
+									{optionalSelectedCount}{" "}
+									optional permissions
+								</p>
+							</div>
+							<p className="text-[11px] text-foreground/50">
+								Only selected permissions are
+								requested on the next screen.
+							</p>
+						</div>
 					</div>
 
 					{/* OAuth sign in button */}
@@ -340,7 +370,7 @@ export function LoginButton({ redirectTo }: { redirectTo?: string }) {
 						)}
 						{loading
 							? "Redirecting..."
-							: "Continue with GitHub"}
+							: `Continue with GitHub (${selectedCount} ${permissionLabel})`}
 						{!loading && (
 							<ArrowRightIcon className="w-3.5 h-3.5 ml-auto" />
 						)}


### PR DESCRIPTION
#### Why 

Users are skipping over the permissions picker and clicking **Continue with GitHub**, which makes it look like Better Hub always requests full GitHub access by default.


#### What changed
- Updated OAuth permissions heading/copy to explicitly tell users to choose access before connecting
- Added a visual legend for permission states (`Required` vs `Selected optional`)
- Added a live permissions summary above the CTA
- Added trust copy near the CTA clarifying only selected permissions are requested
- Updated CTA label to include selected permission count so the button and scope selection feel connected

#### Result
The permissions UI is now much more explicit, reducing the chance that users assume full-scope access is always requested.

##### Before: 
![before](https://github.com/user-attachments/assets/418895af-50e0-4708-b6cb-2bd346bfbc15)

##### After: 
 ![after](https://github.com/user-attachments/assets/ffe6cd0b-b6d2-45b6-924e-f56abec31d34) 

