### PR TITLE
fix: improve contribution chart label spacing and stable hover tooltip

### DIFF
--- a/apps/web/src/components/dashboard/contribution-chart.tsx
+++ b/apps/web/src/components/dashboard/contribution-chart.tsx
@@ -40,9 +40,8 @@ const LEVEL_CLASSES = [
 
 const CELL = 10;
 const GAP = 3;
-const MONTH_LABEL_TEXT_WIDTH_PX = 24;
 const MONTH_LABEL_MIN_GAP_PX = 8;
-const MONTH_LABEL_MIN_SPACING_PX = MONTH_LABEL_TEXT_WIDTH_PX + MONTH_LABEL_MIN_GAP_PX;
+const MONTH_LABEL_MIN_SPACING_PX = 24 + MONTH_LABEL_MIN_GAP_PX;
 const TOOLTIP_EDGE_PADDING_PX = 8;
 const FALLBACK_TOOLTIP_WIDTH_PX = 120;
 
@@ -81,11 +80,20 @@ export function ContributionChart({ data }: { data: ContributionData }) {
 	}, [data.weeks]);
 
 	const visibleMonthPositions = useMemo(() => {
-		let previousRightEdge = Number.NEGATIVE_INFINITY;
-		return monthPositions.filter(({ col }) => {
+		const candidates = monthPositions.filter((month, index, all) => {
+			if (index !== 0) return true;
+			const next = all[1];
+			if (!next) return true;
+			const firstLeft = month.col * (CELL + GAP);
+			const nextLeft = next.col * (CELL + GAP);
+			return nextLeft - firstLeft >= MONTH_LABEL_MIN_SPACING_PX;
+		});
+
+		let previousLeft = Number.NEGATIVE_INFINITY;
+		return candidates.filter(({ col }) => {
 			const left = col * (CELL + GAP);
-			if (left - previousRightEdge < MONTH_LABEL_MIN_SPACING_PX) return false;
-			previousRightEdge = left + MONTH_LABEL_TEXT_WIDTH_PX;
+			if (left - previousLeft < MONTH_LABEL_MIN_SPACING_PX) return false;
+			previousLeft = left;
 			return true;
 		});
 	}, [monthPositions]);


### PR DESCRIPTION
## Summary

  Improves contribution chart readability and hover behavior on profile pages.

  ## Changes

  - Added month label spacing logic to prevent overlap in dense areas (for example near Feb/Mar transitions).
  - Made month extraction safer and more consistent for date parsing.
  - Kept tooltip horizontally clamped so it does not overflow left or right edges.
  - Switched tooltip to a stable top-pinned position for easier scanning while hovering across cells.

  ## Why

  The chart had two UX issues:

  - Month labels could collide and become unreadable.
  - Hover tooltip behavior near edges was inconsistent and harder to scan quickly.

  This update makes the chart more predictable and easier to read across profiles and viewport sizes.

  ## Validation

  - Verified month labels no longer overlap in the left-edge collision case.
  - Verified tooltip remains in-bounds horizontally at both chart edges.
  - Verified tooltip content updates correctly while hovering different contribution cells

  ## Notes
  I am not entirely sure if the right UX move was to move the tooltip pinned to the top, but it does improve the reading experience and is ultimately your choice whether to accept that. I am fully open to any requests/changes.