### PR TITLE
Refresh ghost history on save; sort by last msg

### DIFF
--- a/apps/web/src/components/shared/ai-chat.tsx
+++ b/apps/web/src/components/shared/ai-chat.tsx
@@ -944,8 +944,11 @@ export function AIChat({
 				setConversationId(firstFulfilled.value.conversation.id);
 			}
 			lastSavedCountRef.current = messages.length;
+			if (persistKey?.startsWith("ghost::")) {
+				globalChat?.notifyGhostHistoryChanged?.();
+			}
 		});
-	}, [messages, status, persistKey, chatType, historyLoaded]);
+	}, [messages, status, persistKey, chatType, historyLoaded, globalChat]);
 
 	// Track whether user has scrolled away from the bottom
 	const isUserScrolledUp = useRef(false);

--- a/apps/web/src/components/shared/global-chat-panel.tsx
+++ b/apps/web/src/components/shared/global-chat-panel.tsx
@@ -171,6 +171,7 @@ export function GlobalChatPanel() {
 		switchTab,
 		renameTab,
 		replaceCurrentTab,
+		registerGhostHistoryRefetch,
 	} = useGlobalChat();
 	const [contexts, setContexts] = useState<InlineContext[]>([]);
 	const prevContextKeyRef = useRef<string | null>(null);
@@ -187,7 +188,7 @@ export function GlobalChatPanel() {
 	const [ghostHistory, setGhostHistory] = useState<
 		{ contextKey: string; title: string; updatedAt: string }[]
 	>([]);
-	useEffect(() => {
+	const fetchGhostHistory = useCallback(() => {
 		fetch("/api/ai/chat-history?list=ghost")
 			.then((res) => res.json())
 			.then((data) => {
@@ -209,6 +210,14 @@ export function GlobalChatPanel() {
 			})
 			.catch(() => {});
 	}, []);
+	useEffect(() => {
+		if (!state.isOpen) return;
+		fetchGhostHistory();
+	}, [state.isOpen, fetchGhostHistory]);
+	useEffect(() => {
+		registerGhostHistoryRefetch(fetchGhostHistory);
+		return () => registerGhostHistoryRefetch(null);
+	}, [registerGhostHistoryRefetch, fetchGhostHistory]);
 
 	const handleLoadHistory = useCallback(
 		(contextKey: string, title: string) => {

--- a/apps/web/src/lib/chat-store.ts
+++ b/apps/web/src/lib/chat-store.ts
@@ -175,15 +175,33 @@ export async function listGhostConversations(
 	userId: string,
 	limit = 10,
 ): Promise<ChatConversation[]> {
-	const rows = await prisma.chatConversation.findMany({
-		where: {
-			userId,
-			contextKey: { startsWith: "ghost::" },
-			title: { not: null },
-		},
-		orderBy: { updatedAt: "desc" },
-		take: limit,
-	});
+	// Sort by last message timestamp (not conversation.updatedAt) so "Recent" reflects
+	// when the last prompt was sent, not when the conversation was created.
+	// NOTE: Schema changes to ChatConversation or ChatMessage require updating this raw query.
+	type ChatConversationRow = {
+		id: string;
+		userId: string;
+		chatType: string;
+		contextKey: string;
+		title: string | null;
+		activeStreamId: string | null;
+		createdAt: string;
+		updatedAt: string;
+	};
+	const rows = await prisma.$queryRaw<ChatConversationRow[]>`
+		SELECT c.id, c."userId", c."chatType", c."contextKey", c.title, c."activeStreamId", c."createdAt", c."updatedAt"
+		FROM chat_conversations c
+		LEFT JOIN (
+			SELECT "conversationId", MAX("createdAt") as last_msg_at
+			FROM chat_messages
+			GROUP BY "conversationId"
+		) m ON c.id = m."conversationId"
+		WHERE c."userId" = ${userId}
+			AND c."contextKey" LIKE 'ghost::%'
+			AND c.title IS NOT NULL
+		ORDER BY COALESCE(m.last_msg_at, c."updatedAt") DESC
+		LIMIT ${limit}
+	`;
 	return rows.map(toConversation);
 }
 


### PR DESCRIPTION
Register and trigger ghost-history refetches so the Global Chat panel updates when ghost conversations change. Adds registerGhostHistoryRefetch and notifyGhostHistoryChanged to the global chat context, calls notify when AIChat persists a ghost conversation, and wires GlobalChatPanel to register/unregister a fetchGhostHistory callback and invoke it when the panel opens.

Also reworks listGhostConversations to use a raw query that orders ghost conversations by the timestamp of their last message (falling back to conversation.updatedAt), so the "Recent" ordering reflects the last prompt time. Includes a comment noting schema coupling for the raw query.