### PR TITLE
Emit notification read events

### DIFF
--- a/apps/web/src/app/(app)/repos/actions.ts
+++ b/apps/web/src/app/(app)/repos/actions.ts
@@ -60,6 +60,7 @@ export async function markNotificationDone(threadId: string) {
 	try {
 		await octokit.activity.markThreadAsRead({ thread_id: Number(threadId) });
 		revalidatePath("/notifications");
+		revalidatePath("/dashboard", "layout");
 		return { success: true };
 	} catch (e: unknown) {
 		return { error: getErrorMessage(e) || "Failed to mark notification as done" };
@@ -72,6 +73,7 @@ export async function markAllNotificationsRead() {
 	try {
 		await octokit.activity.markNotificationsAsRead();
 		revalidatePath("/notifications");
+		revalidatePath("/dashboard", "layout");
 		return { success: true };
 	} catch (e: unknown) {
 		return { error: getErrorMessage(e) || "Failed to mark all as read" };

--- a/apps/web/src/lib/mutation-events.ts
+++ b/apps/web/src/lib/mutation-events.ts
@@ -133,6 +133,11 @@ export type GitHubAccountAddedEvent = { type: "github-account:added" };
 export type GitHubAccountRemovedEvent = { type: "github-account:removed" };
 export type GitHubAccountSwitchedEvent = { type: "github-account:switched" };
 
+// ── Notification Events ──────────────────────────────────────
+
+export type NotificationReadEvent = { type: "notification:read"; id: string };
+export type NotificationAllReadEvent = { type: "notification:all-read"; ids: string[] };
+
 // ── Discriminated Union ───────────────────────────────────────
 
 export type MutationEvent =
@@ -172,7 +177,9 @@ export type MutationEvent =
 	| CodeThemeDeletedEvent
 	| GitHubAccountAddedEvent
 	| GitHubAccountRemovedEvent
-	| GitHubAccountSwitchedEvent;
+	| GitHubAccountSwitchedEvent
+	| NotificationReadEvent
+	| NotificationAllReadEvent;
 
 export type MutationEventType = MutationEvent["type"];
 


### PR DESCRIPTION
Add NotificationReadEvent and NotificationAllReadEvent to mutation-events and include them in the MutationEvent union. Revalidate the dashboard layout when notifications are marked read in actions. Wire up useMutationEvents across Dashboard, Navbar and Notifications components to emit and subscribe to optimistic notification-read / all-read updates; maintain a doneIds set to hide recently marked notifications and perform optimistic UI updates (with rollback on failure) in the navbar. These changes enable centralized mutation events for notification state and ensure the dashboard/layout is refreshed when notifications change.