### PR TITLE
Fix: Fallback to GraphQL when REST API returns null language from forked repos on user repos list

### DIFF
--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -927,7 +927,7 @@ async function fetchUserProfileFromGitHub(octokit: Octokit, username: string) {
 
 async function enrichMissingRepoLanguagesFromGraphQL<
 	T extends {
-		language: string | null;
+		language?: string | null;
 		name: string;
 		owner?: { login?: string | null } | null;
 	},
@@ -996,12 +996,14 @@ async function enrichMissingRepoLanguagesFromGraphQL<
 	}
 }
 
+type UserPublicRepo = Awaited<ReturnType<Octokit["repos"]["listForUser"]>>["data"][number];
+
 async function fetchUserPublicReposFromGitHub(
 	octokit: Octokit,
 	username: string,
 	perPage: number,
 	token?: string | null,
-) {
+): Promise<UserPublicRepo[]> {
 	// Fetch recently-updated repos for the listing + top-starred repos via
 	// search API for accurate profile scoring (listForUser can't sort by stars).
 	const half = Math.ceil(perPage / 2);
@@ -1022,7 +1024,7 @@ async function fetchUserPublicReposFromGitHub(
 	}
 	// Merge and deduplicate — recently-updated first, then top-starred fills gaps
 	const seen = new Set<number>();
-	const merged = [];
+	const merged: UserPublicRepo[] = [];
 	for (const repo of byUpdated.data) {
 		seen.add(repo.id);
 		merged.push(repo);


### PR DESCRIPTION


This PR resolves an issue where the GitHub REST API returns `null` for the `language` field.  
This is misleading because the repository may still contain multiple languages.

When the REST API returns `null`, the GraphQL result (or the `/languages` endpoint) is now used as a fallback to determine the primary language.



The REST API sometimes returns:

```json
{
  "language": null
}
```

Example:

```bash
curl -s "https://api.github.com/repos/Esubaalew/better-hub" \
| jq '{full_name, fork, language, default_branch}'

echo '---'

curl -s "https://api.github.com/repos/Esubaalew/better-hub/languages" \
| jq '.'
```

Output:

```json
{
  "full_name": "Esubaalew/better-hub",
  "fork": true,
  "language": null,
  "default_branch": "main"
}

{
  "TypeScript": 2340094,
  "CSS": 27748,
  "HTML": 18910,
  "JavaScript": 15945,
  "Dockerfile": 640
}
```




## Before / After

<table>
<tr>
<td><b>Before</b></td>
<td><b>After</b></td>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/de5b23f9-8be5-457c-a406-ab185d6b88fb" width="450">
</td>
<td>
<img src="https://github.com/user-attachments/assets/100514b9-02e8-4faa-844a-81a922e0e26a" width="450">
</td>
</tr>
</table>