### PR TITLE
fix: unify commits toolbar height and styling

### DIFF
--- a/apps/web/src/components/repo/commits-list.tsx
+++ b/apps/web/src/components/repo/commits-list.tsx
@@ -121,11 +121,11 @@ function BranchPicker({
 		<div className="relative">
 			<button
 				onClick={() => setOpen(!open)}
-				className="flex items-center gap-1.5 px-3 py-2 text-[11px] font-mono border border-border hover:bg-muted/60 dark:hover:bg-white/3 transition-colors cursor-pointer"
+				className="flex items-center gap-1.5 h-9 px-3 text-xs font-mono rounded-md border border-border hover:bg-muted/60 dark:hover:bg-white/3 transition-colors cursor-pointer"
 			>
-				<GitBranch className="w-3 h-3 text-muted-foreground/70" />
+				<GitBranch className="w-3.5 h-3.5 text-muted-foreground/70" />
 				<span className="max-w-[140px] truncate">{currentBranch}</span>
-				<ChevronDown className="w-3 h-3 text-muted-foreground/50" />
+				<ChevronDown className="w-3.5 h-3.5 text-muted-foreground/50" />
 			</button>
 			{open && (
 				<>
@@ -266,7 +266,7 @@ function CommitsToolbar({
 					placeholder="Search commits..."
 					value={search}
 					onChange={(e) => onSearchChange(e.target.value)}
-					className="w-full rounded-md border border-border bg-background px-3 py-2 pl-9 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+					className="w-full h-9 rounded-md border border-border bg-background px-3 pl-9 text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
 				/>
 				<svg
 					className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/50"
@@ -288,20 +288,20 @@ function CommitsToolbar({
 				value={since}
 				onChange={(e) => onSinceChange(e.target.value)}
 				title="Since date"
-				className="rounded-md border border-border bg-background px-2 py-2 font-mono text-xs text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+				className="h-9 rounded-md border border-border bg-background px-3 font-mono text-xs text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
 			/>
 			<input
 				type="date"
 				value={until}
 				onChange={(e) => onUntilChange(e.target.value)}
 				title="Until date"
-				className="rounded-md border border-border bg-background px-2 py-2 font-mono text-xs text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+				className="h-9 rounded-md border border-border bg-background px-3 font-mono text-xs text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
 			/>
 			{hasDateFilter && (
 				<button
 					onClick={onClearDates}
 					title="Clear date filters"
-					className="rounded-md border border-border bg-background px-2 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground cursor-pointer"
+					className="h-9 rounded-md border border-border bg-background px-3 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground cursor-pointer"
 				>
 					✕
 				</button>


### PR DESCRIPTION
## Problem
The commits page toolbar had inconsistent heights between the branch picker, search input, and date filter inputs:
- **Branch picker**: `py-2` only, no explicit height, no border radius
- **Search input**: `py-2`, had `rounded-md`  
- **Date inputs**: `px-2 py-2`, had `rounded-md` but different horizontal padding
- **Clear button**: `px-2 py-2`, had `rounded-md` but different padding

This caused visual misalignment where elements had different heights (especially noticeable between the branch picker and other elements).

## Solution
Applied consistent styling across all toolbar elements:

| Element | Before | After |
|---------|--------|-------|
| Branch picker | `px-3 py-2 text-[11px]` | `h-9 px-3 text-xs rounded-md` |
| Search input | `px-3 py-2 pl-9 text-sm` | `h-9 px-3 pl-9 text-sm` |
| Date inputs | `px-2 py-2 text-xs` | `h-9 px-3 text-xs` |
| Clear button | `px-2 py-2 text-xs` | `h-9 px-3 text-xs` |

### Changes
- **Unified height**: All elements now use `h-9` (36px) for consistent vertical alignment
- **Unified horizontal padding**: All elements use `px-3` 
- **Unified border radius**: Added `rounded-md` to branch picker (others already had it)
- **Standardized text size**: Branch picker changed from `text-[11px]` to `text-xs` for consistency

## Visual Result
All toolbar elements now have the same 36px height and align perfectly horizontally.

## Testing
- [x] Verified all toolbar elements render at same height
- [x] Checked branch picker dropdown still works correctly
- [x] Verified date inputs and clear button functionality unchanged
- [x] Code formatted with `pnpm fmt`