### PR TITLE
Instant cache reload when navigating pages

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -26,7 +26,7 @@ const nextConfig: NextConfig = {
 	serverExternalPackages: ["@prisma/client"],
 	experimental: {
 		staleTimes: {
-			dynamic: 300,
+			dynamic: 0,
 			static: 180,
 		},
 	},


### PR DESCRIPTION
This is more of a personal change, I repeatedly ran into the issue of when a PR gets merged or something gets updated I don't get a notification or see it on the dashboard until I manually CMD+R, not sure if you want the stale time to be 0 or stay at 300, or simply be reduced to 120 or 180.