### PR TITLE
fix: prevent Clear button from overlapping repo count in filter bar

### DIFF
--- a/apps/web/src/components/users/user-profile-content.tsx
+++ b/apps/web/src/components/users/user-profile-content.tsx
@@ -20,6 +20,7 @@ import {
 	Star,
 	Twitter,
 	Users,
+	X,
 } from "lucide-react";
 import { cn, formatNumber } from "@/lib/utils";
 import { getLanguageColor } from "@/lib/github-utils";
@@ -632,9 +633,9 @@ export function UserProfileContent({
 						</button>
 					</div>
 
-					<div className="flex items-center justify-between mb-4">
+					<div className="flex items-start justify-between gap-4 mb-4">
 						{languages.length > 0 && (
-							<div className="flex items-center gap-1.5 flex-wrap flex-1">
+							<div className="flex items-center gap-1.5 flex-wrap flex-1 mt-0.5">
 								{topLanguages.map((lang) => (
 									<button
 										key={lang}
@@ -759,18 +760,21 @@ export function UserProfileContent({
 								)}
 							</div>
 						)}
-						{(search || languageFilter) && (
-							<button
-								onClick={clearRepoFilters}
-								aria-label="Clear repository filters"
-								className="ml-2 text-[11px] text-muted-foreground hover:text-foreground font-mono transition-colors"
-							>
-								Clear
-							</button>
-						)}
-						<span className="text-[11px] text-muted-foreground/30 font-mono shrink-0 ml-auto">
-							{filtered.length}/{repos.length}
-						</span>
+						<div className="flex items-center gap-3 shrink-0 ml-auto pt-1">
+							{(search || languageFilter) && (
+								<button
+									onClick={clearRepoFilters}
+									aria-label="Clear repository filters"
+									className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground font-mono transition-colors"
+								>
+									<X className="w-3 h-3" />
+									Clear
+								</button>
+							)}
+							<span className="text-[11px] text-muted-foreground/30 font-mono tabular-nums">
+								{filtered.length}/{repos.length}
+							</span>
+						</div>
 					</div>
 				</div>
 


### PR DESCRIPTION
## What changed

The "Clear" button in the repository filter bar was rendered in the same flex row as the repo count, causing it to overlap and visually collide with the count when a language or search filter was active.

##Before
<img width="211" height="142" alt="Screenshot 2026-02-27 at 8 54 32 PM" src="https://github.com/user-attachments/assets/748220be-bb99-457a-b4bc-23aef40de83c" />

##After
<img width="241" height="135" alt="Screenshot 2026-02-27 at 8 54 09 PM" src="https://github.com/user-attachments/assets/4e332dbf-2d86-4666-bab6-9374abf8954f" />


## Why
Poor UX — the count was unreadable and the Clear affordance was awkwardly placed with no visual separation from adjacent elements.

## How

- Grouped "Clear" and the repo count into a dedicated right-aligned `div` so they always sit together as a unit
- Added an `X` icon to the Clear button to make its intent immediately obvious at a glance
- Changed layout from `items-center justify-between` to `items-start` with explicit `ml-auto` on the right group, preventing reflow issues when the language pills wrap to a second line