### PR TITLE
fix: clicking repo name in breadcrumb now goes to /code instead of overview

### DIFF
--- a/apps/web/src/components/repo/breadcrumb-nav.tsx
+++ b/apps/web/src/components/repo/breadcrumb-nav.tsx
@@ -27,7 +27,7 @@ export function BreadcrumbNav({ owner, repo, currentRef, path, isFile }: Breadcr
 	return (
 		<nav className="flex items-center gap-1 text-xs font-mono overflow-x-auto">
 			<Link
-				href={`/${owner}/${repo}`}
+				href={`/${owner}/${repo}/code`}
 				className="text-muted-foreground hover:text-foreground transition-colors shrink-0"
 			>
 				{repo}


### PR DESCRIPTION
The repo name in the breadcrumb navigation was linking to the repository root (`/${owner}/${repo}`), which shows the overview page.

Changes
- Updated breadcrumb repo link to point to `/${owner}/${repo}/code` instead of the root path

This has a better UX