### PR TITLE
chore: update catppuccin theme

### DIFF
--- a/apps/web/src/lib/themes/themes.tsx
+++ b/apps/web/src/lib/themes/themes.tsx
@@ -5958,10 +5958,10 @@ export const catppuccin: ThemeDefinition = {
 			"--alert-warning": "#f9e2af",
 			"--alert-caution": "#f38ba8",
 			"--contrib-0": "#313244",
-			"--contrib-1": "#1e2b5b",
-			"--contrib-2": "#30418a",
-			"--contrib-3": "#4963c4",
-			"--contrib-4": "#89b4fa",
+			"--contrib-1": "#263c5a",
+			"--contrib-2": "#385984",
+			"--contrib-3": "#6a8eca",
+			"--contrib-4": "#92b3f5",
 		},
 		syntax: convertToShikiTheme(
 			{


### PR DESCRIPTION
addresses https://github.com/better-auth/better-hub/pull/220#issuecomment-3976138918

Changed color to blue, sorry to bother you. You were too quick with the merge haha 

<img width="1494" height="821" alt="image" src="https://github.com/user-attachments/assets/752cfcce-edcb-4c52-b3ba-ac3d2be4735b" />

<img width="1493" height="820" alt="image" src="https://github.com/user-attachments/assets/51917b03-3097-4b65-a594-de73577b09f2" />

I'm still not sure about the contribution colors, and the badge text in light mode is too light I think