### PR TITLE
feat: linkify full commit SHAs in markdown

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -488,6 +488,14 @@ tr.diff-search-match-active > td {
 	white-space: nowrap;
 }
 
+/* commit hashes */
+.ghmd a.ghmd-commit-ref {
+	text-decoration: none;
+	color: var(--primary);
+	font-weight: 500;
+	white-space: nowrap;
+}
+
 /* Bold / italic */
 .ghmd strong {
 	font-weight: 600;


### PR DESCRIPTION
Converts full 40-character commit SHAs found in markdown content to clickable links pointing to the commit page (`/{owner}/{repo}/commit/{sha}`).