### PR TITLE
fix(ui): avoid commit fetch crash on empty repositories

### DIFF
--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.test.ts
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const getRepoCommitsMock = mock();
+
+mock.module("@/lib/github", () => ({
+	getRepoCommits: getRepoCommitsMock,
+	getCommit: mock(),
+}));
+
+mock.module("@/lib/shiki", () => ({
+	highlightDiffLines: mock(async () => ({})),
+}));
+
+describe("fetchLatestCommit", () => {
+	beforeEach(() => {
+		getRepoCommitsMock.mockReset();
+	});
+
+	it("returns null when listing commits fails (empty repository)", async () => {
+		getRepoCommitsMock.mockRejectedValueOnce(new Error("Git Repository is empty."));
+
+		const { fetchLatestCommit } = await import("./actions");
+		const result = await fetchLatestCommit("owner", "empty-repo");
+
+		expect(result).toBeNull();
+		expect(getRepoCommitsMock).toHaveBeenCalledWith("owner", "empty-repo", undefined, 1, 1);
+	});
+});

--- a/apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.ts
+++ b/apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.ts
@@ -41,19 +41,23 @@ export async function fetchCommitsPage(
 }
 
 export async function fetchLatestCommit(owner: string, repo: string) {
-	const commits = await getRepoCommits(owner, repo, undefined, 1, 1);
-	const c = commits[0];
-	if (!c) return null;
-	return {
-		sha: c.sha,
-		message: (c.commit.message ?? "").split("\n")[0],
-		date: c.commit.author?.date ?? c.commit.committer?.date ?? "",
-		author: c.author
-			? { login: c.author.login, avatarUrl: c.author.avatar_url }
-			: c.commit.author?.name
-				? { login: c.commit.author.name, avatarUrl: "" }
-				: null,
-	};
+	try {
+		const commits = await getRepoCommits(owner, repo, undefined, 1, 1);
+		const c = commits[0];
+		if (!c) return null;
+		return {
+			sha: c.sha,
+			message: (c.commit.message ?? "").split("\n")[0],
+			date: c.commit.author?.date ?? c.commit.committer?.date ?? "",
+			author: c.author
+				? { login: c.author.login, avatarUrl: c.author.avatar_url }
+				: c.commit.author?.name
+					? { login: c.commit.author.name, avatarUrl: "" }
+					: null,
+		};
+	} catch {
+		return null;
+	}
 }
 
 export type CommitDetailData = {


### PR DESCRIPTION
## Problem
Opening a repository page can fail when the repository has no commits yet.

## Root cause
`fetchLatestCommit` directly calls `getRepoCommits(..., 1, 1)`. For empty repositories, this call may reject, which bubbles up and can break page rendering.

## Fix
- Wrapped `getRepoCommits` in `fetchLatestCommit` with a safe `try/catch`.
- Return `null` when commit listing fails, so UI can render the empty-repo state gracefully.

## Tests
Added a focused regression test:
- `apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.test.ts`
- Verifies `fetchLatestCommit` returns `null` when commit listing rejects for an empty repository.

Test command run:
- `bun test apps/web/src/app/(app)/repos/[owner]/[repo]/commits/actions.test.ts`
- Result: `1 pass`

## Impact
Improves empty-repository resilience and prevents runtime failures in repo pages with no commit history.

Refs #278
