### PR TITLE
fix: responsive layout for settings dialog, theme grid and border radius grid

### DIFF
--- a/apps/web/src/components/settings/settings-content.tsx
+++ b/apps/web/src/components/settings/settings-content.tsx
@@ -102,7 +102,7 @@ export function SettingsContent({
 	}
 
 	return (
-		<div className="flex flex-col flex-1 min-h-0">
+		<div className="flex flex-col flex-1 min-h-0 min-w-0 w-full overflow-hidden">
 			{/* Header */}
 			<div className="shrink-0 px-6 pt-6 pb-4">
 				<h1 className="text-xl font-medium tracking-tight">Settings</h1>
@@ -121,7 +121,7 @@ export function SettingsContent({
 						className={cn(
 							"flex items-center gap-1.5 px-3 sm:px-4 py-2.5 text-[11px] font-mono uppercase tracking-wider whitespace-nowrap shrink-0 transition-colors cursor-pointer",
 							activeTab === id
-								? "text-foreground bg-muted/50 dark:bg-white/[0.04]"
+								? "text-foreground bg-muted/50 dark:bg-white/4"
 								: "text-muted-foreground hover:text-foreground/60",
 						)}
 					>
@@ -132,7 +132,7 @@ export function SettingsContent({
 			</div>
 
 			{/* Content — only this area scrolls */}
-			<div className="flex-1 min-h-0 overflow-y-auto border border-t-0 border-border mx-6 mb-6">
+			<div className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden border border-t-0 border-border mx-6 mb-6">
 				{activeTab === "general" && (
 					<GeneralTab
 						settings={settings}

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -95,7 +95,7 @@ export function SettingsDialog({
 				<VisuallyHidden.Root>
 					<DialogTitle>Settings</DialogTitle>
 				</VisuallyHidden.Root>
-				<div className="flex flex-col max-h-[85vh] min-h-[26rem]">
+				<div className="flex flex-col max-h-[85vh] min-h-104 overflow-hidden">
 					{settings && !isError ? (
 						<SettingsContent
 							key={initialTab}
@@ -118,7 +118,7 @@ export function SettingsDialog({
 										onClick={() =>
 											void refetch()
 										}
-										className="border border-border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground hover:bg-muted/50 dark:hover:bg-white/[0.04] transition-colors cursor-pointer"
+										className="border border-border px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground hover:bg-muted/50 dark:hover:bg-white/4 transition-colors cursor-pointer"
 									>
 										Retry
 									</button>

--- a/apps/web/src/components/settings/tabs/general-tab.tsx
+++ b/apps/web/src/components/settings/tabs/general-tab.tsx
@@ -25,7 +25,7 @@ function ThemeGrid({
 	onSelect: (id: string) => void;
 }) {
 	return (
-		<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+		<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 w-full">
 			{themes.map((theme) => {
 				const isActive = activeId === theme.id;
 				const variant = theme[mode];
@@ -34,9 +34,9 @@ function ThemeGrid({
 						key={theme.id}
 						onClick={() => onSelect(theme.id)}
 						className={cn(
-							"group relative flex items-center gap-3 border px-3 py-2.5 text-left transition-colors cursor-pointer",
+							"group relative w-full flex items-center gap-3 border px-3 py-2.5 text-left transition-colors cursor-pointer",
 							isActive
-								? "border-foreground/30 bg-muted/50 dark:bg-white/[0.04]"
+								? "border-foreground/30 bg-muted/50 dark:bg-white/4"
 								: "border-border hover:border-foreground/10 hover:bg-muted/30",
 						)}
 					>
@@ -58,8 +58,8 @@ function ThemeGrid({
 						</div>
 
 						<div className="flex-1 min-w-0">
-							<div className="flex items-center gap-1.5">
-								<span className="text-xs font-mono font-medium text-foreground">
+							<div className="flex items-center gap-1.5 min-w-0">
+								<span className="text-xs font-mono font-medium text-foreground truncate">
 									{theme.name}
 								</span>
 							</div>
@@ -69,7 +69,7 @@ function ThemeGrid({
 						</div>
 
 						{isActive && (
-							<Check className="size-3.5 text-success shrink-0" />
+							<Check className="size-3.5 text-success shrink-0 ml-auto" />
 						)}
 					</button>
 				);


### PR DESCRIPTION
## Problem
On small screens, the settings dialog had three responsive issues:
- The tab bar (General, Editor, AI/Model, Billing, Account) was overflowing horizontally and cutting off the last tab instead of scrolling
- The check icon in the theme grid was being cut off / not visible because buttons had no width constraint
- The border radius grid items were overflowing horizontally on small screens

## Solution

**`settings-dialog.tsx`**
- Added `overflow-hidden` to the inner flex container to prevent content from bleeding outside the dialog

**`settings-content.tsx`**
- Added `min-w-0 w-full overflow-hidden` to the root wrapper so it respects the dialog width
- Added `min-w-0 overflow-x-hidden` to the content scroll area to clip any horizontal overflow

**`general-tab.tsx`**
- Added `w-full` to the grid container and each theme button so buttons fill their grid cell properly
- Added `min-w-0` to the inner text div and `truncate` to the theme name span so long names don't push the check icon out
- Added `ml-auto` to the check icon so it always stays pinned to the right edge

## Screenshots

### Tab bar scrolling fix
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/c92c8c54-2b7b-4006-a6db-3f0486974070" width="300" /> | <img src="https://github.com/user-attachments/assets/9f73cd2f-49b1-4035-a5ec-8b22781aa33a" width="300" /> |

### Theme grid check icon fix
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/4cb73bbd-5253-4377-bb0a-7f92501e1713" width="300" /> | <img src="https://github.com/user-attachments/assets/71a3f181-3228-4978-a2b7-a2bc6484c8e9" width="300" /> |

### Border radius grid fix
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/be3f07cf-c221-4fb1-a8c5-edbee648a2dc" width="300" /> | <img src="https://github.com/user-attachments/assets/4e8d8a5c-519e-45ba-878f-161e277fb648" width="300" /> |