### PR TITLE
fix: content width on sidebar resize

### DIFF
--- a/apps/web/src/components/repo/repo-sidebar.tsx
+++ b/apps/web/src/components/repo/repo-sidebar.tsx
@@ -97,7 +97,7 @@ export function RepoSidebar({
 	return (
 		<>
 			{/* Desktop sidebar */}
-			<aside className="hidden lg:flex w-[260px] shrink-0 overflow-y-auto pt-0 pr-2 pl-4 pb-4 flex-col gap-5">
+			<aside className="hidden lg:flex shrink-0 overflow-y-auto pt-0 pr-2 pl-4 pb-4 flex-col gap-5">
 				{/* Name + Avatar + Description + Badges */}
 				<div className="flex flex-col gap-2">
 					<RepoBreadcrumb


### PR DESCRIPTION
<details>
  <summary>Before</summary>
  
  <img width="2820" height="1670" alt="image" src="https://github.com/user-attachments/assets/597d88c0-c6cb-445b-8d44-2c14db42eb3f" />

</details>

<details>
  <summary>After</summary>
  
  
  <img width="2820" height="1670" alt="image" src="https://github.com/user-attachments/assets/4166a410-9a58-4a40-9fbd-dcd24cc984bb" />

</details>