### PR TITLE
fix: responsive mobile layout for tags list and commits toolbar

### DIFF
--- a/apps/web/src/components/repo/commits-list.tsx
+++ b/apps/web/src/components/repo/commits-list.tsx
@@ -48,12 +48,12 @@ type Commit = {
 		} | null;
 	};
 	author:
-	| {
-		login: string;
-		avatar_url: string;
-	}
-	| Record<string, never>
-	| null;
+		| {
+				login: string;
+				avatar_url: string;
+		  }
+		| Record<string, never>
+		| null;
 	html_url: string;
 };
 
@@ -72,10 +72,10 @@ function groupByDate(commits: Commit[]) {
 		const date = commit.commit.author?.date;
 		const key = date
 			? new Date(date).toLocaleDateString("en-US", {
-				month: "long",
-				day: "numeric",
-				year: "numeric",
-			})
+					month: "long",
+					day: "numeric",
+					year: "numeric",
+				})
 			: "Unknown date";
 		if (!groups[key]) groups[key] = [];
 		groups[key].push(commit);
@@ -178,7 +178,7 @@ function BranchPicker({
 										className={cn(
 											"w-full text-left px-3 py-1.5 text-xs font-mono hover:bg-muted/60 dark:hover:bg-white/3 transition-colors cursor-pointer flex items-center gap-2",
 											isActive &&
-											"bg-muted/30",
+												"bg-muted/30",
 										)}
 									>
 										<span className="w-3.5 shrink-0 flex items-center justify-center">
@@ -572,7 +572,7 @@ function CommitDetailSheet({
 			>
 				<ResizeHandle
 					onResize={onResize}
-					onDragStart={() => { }}
+					onDragStart={() => {}}
 					onDragEnd={onResizeEnd}
 					onDoubleClick={onResetWidth}
 					className="absolute left-0 inset-y-0 z-20"
@@ -862,8 +862,8 @@ export function CommitsList({ owner, repo, commits, defaultBranch, branches }: C
 	const hasDateFilter = since !== "" || until !== "";
 	const filtered = search
 		? displayedCommits.filter((c) =>
-			c.commit.message.toLowerCase().includes(search.toLowerCase()),
-		)
+				c.commit.message.toLowerCase().includes(search.toLowerCase()),
+			)
 		: displayedCommits;
 	const grouped = groupByDate(filtered);
 

--- a/apps/web/src/components/repo/tags-list.tsx
+++ b/apps/web/src/components/repo/tags-list.tsx
@@ -163,7 +163,9 @@ export function TagsList({
 												href={`/${owner}/${repo}/releases/${tag.name}`}
 												className="text-sm font-mono font-medium text-foreground truncate hover:underline hover:cursor-pointer"
 											>
-												{tag.name}
+												{
+													tag.name
+												}
 											</Link>
 											{release &&
 												!release.draft && (
@@ -176,9 +178,11 @@ export function TagsList({
 														) : (
 															<span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 max-w-50 md:max-w-none">
 																<Rocket className="w-2.5 h-2.5 shrink-0" />
-																<span className="truncate md:truncate-none">{release.name || release.tag_name}</span>
+																<span className="truncate md:truncate-none">
+																	{release.name ||
+																		release.tag_name}
+																</span>
 															</span>
-
 														)}
 													</>
 												)}


### PR DESCRIPTION
## Problem

### Tags List
On mobile devices, the tags list had two issues:
- Action buttons (`Release`, `zip`, `tar.gz`) were hover-only and completely
  invisible on touch devices, making downloads inaccessible on mobile
- Long release names in the badge overflowed and overlapped with action
  buttons since there was no width constraint

### Commits Toolbar
On mobile devices, the commits toolbar had two issues:
- All controls (branch picker, search, two date inputs) were crammed into
  a single row, causing date inputs to be cut off and inaccessible
- Search input was not full width on mobile, leaving wasted space next to
  the branch picker

## Solution

**`tags-list.tsx`**
- Changed tag row to `flex-col` on mobile and `flex-row` on `md+` so
  actions wrap to a second row below the tag name
- Actions are always visible on mobile, hover-only on `md+` via
  `md:opacity-0 md:group-hover:opacity-100`
- Added `ml-9 md:ml-0` to actions row so it aligns under the tag name
  on mobile, not the icon
- Added `max-w-[200px] md:max-w-none` and `truncate md:truncate-none`
  to release name badge so long names truncate only on mobile

**`commits-list.tsx`**
- Changed toolbar wrapper to `flex-col gap-2 sm:flex-row sm:items-center`
  so controls stack vertically on mobile and align in a row on `sm+`
- Row 1 (mobile): branch picker full width, search input below it full width
- Row 2 (mobile): both date inputs side by side via `flex items-center gap-2`
  with `flex-1` so each takes 50% of the row
- Branch picker dropdown width set to `w-full sm:w-72` so it fills screen on mobile
- Desktop: all controls in a single row, unchanged

## Files Changed
- `apps/web/src/components/repo/tags-list.tsx`
- `apps/web/src/components/repo/commits-list.tsx`

## Screenshots

### Tags list mobile fix
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/94badb04-d4f3-4e1e-be07-1d2c15dab31b" width="300" /> | <img src="https://github.com/user-attachments/assets/d9bc1368-b475-4b24-9f5f-1c4a13cb9092" width="300" /> |

### Commits toolbar mobile fix
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/6dee0e62-328d-4727-97c1-0f0192a9de3d" width="300" /> | <img src="https://github.com/user-attachments/assets/55cb6542-3353-4fe0-9cfe-3faec7f5aeed" width="300" /> |