### PR TITLE
Add team access copying feature for repositories

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -17,6 +17,7 @@ import { MutationEventProvider } from "@/components/shared/mutation-event-provid
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { OnboardingOverlay } from "@/components/onboarding/onboarding-overlay";
+import { CopyTeamAccessPrompt } from "@/components/repo/copy-team-access-prompt";
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
 	const session = await getServerSession();
@@ -85,7 +86,8 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 										</Suspense>
 									</div>
 								</NavVisibilityProvider>
-								<OnboardingOverlay
+								<CopyTeamAccessPrompt />
+							<OnboardingOverlay
 									userName={
 										session?.githubUser
 											?.name ||

--- a/apps/web/src/app/(app)/repos/team-actions.ts
+++ b/apps/web/src/app/(app)/repos/team-actions.ts
@@ -1,0 +1,174 @@
+"use server";
+
+import { getOctokit } from "@/lib/github";
+import { getErrorMessage } from "@/lib/utils";
+
+export type RepoTeam = {
+	name: string;
+	slug: string;
+	permission: string;
+	description: string | null;
+};
+
+export async function listRepoTeams(
+	owner: string,
+	repo: string,
+): Promise<{ teams: RepoTeam[] } | { error: string }> {
+	const octokit = await getOctokit();
+	if (!octokit) return { error: "Not authenticated" };
+	try {
+		const { data } = await octokit.teams.listForRepo({
+			owner,
+			repo,
+			per_page: 100,
+		});
+		return {
+			teams: data.map((t) => ({
+				name: t.name,
+				slug: t.slug,
+				permission: t.permission,
+				description: t.description ?? null,
+			})),
+		};
+	} catch (e: unknown) {
+		return { error: getErrorMessage(e) || "Failed to list teams" };
+	}
+}
+
+export async function addTeamsToRepo(
+	owner: string,
+	repos: string[],
+	teams: { slug: string; permission: string }[],
+): Promise<{ added: { repo: string; team: string }[]; errors: string[] }> {
+	const octokit = await getOctokit();
+	if (!octokit)
+		return { added: [], errors: ["Not authenticated"] };
+
+	const results = await Promise.allSettled(
+		repos.flatMap((repo) =>
+			teams.map((team) =>
+				octokit.teams
+					.addOrUpdateRepoPermissionsInOrg({
+						org: owner,
+						team_slug: team.slug,
+						owner,
+						repo,
+						permission: team.permission as
+							| "pull"
+							| "triage"
+							| "push"
+							| "maintain"
+							| "admin",
+					})
+					.then(() => ({ repo, team: team.slug })),
+			),
+		),
+	);
+
+	const added: { repo: string; team: string }[] = [];
+	const errors: string[] = [];
+
+	for (const result of results) {
+		if (result.status === "fulfilled") {
+			added.push(result.value);
+		} else {
+			errors.push(String(result.reason));
+		}
+	}
+
+	return { added, errors };
+}
+
+export async function copyRepoTeamAccess(
+	owner: string,
+	sourceRepo: string,
+	targetRepos: string[],
+): Promise<{
+	results: {
+		repo: string;
+		team: string;
+		permission: string;
+		success: boolean;
+		error?: string;
+	}[];
+}> {
+	const octokit = await getOctokit();
+	if (!octokit) {
+		return {
+			results: targetRepos.map((repo) => ({
+				repo,
+				team: "Unknown",
+				permission: "Unknown",
+				success: false,
+				error: "Not authenticated",
+			})),
+		};
+	}
+
+	let sourceTeams: RepoTeam[];
+	try {
+		const { data } = await octokit.teams.listForRepo({
+			owner,
+			repo: sourceRepo,
+			per_page: 100,
+		});
+		sourceTeams = data.map((t) => ({
+			name: t.name,
+			slug: t.slug,
+			permission: t.permission,
+			description: t.description ?? null,
+		}));
+	} catch (e: unknown) {
+		return {
+			results: targetRepos.map((repo) => ({
+				repo,
+				team: "Unknown",
+				permission: "Unknown",
+				success: false,
+				error:
+					getErrorMessage(e) ||
+					`Failed to list teams for ${sourceRepo}`,
+			})),
+		};
+	}
+
+	const settled = await Promise.allSettled(
+		targetRepos.flatMap((repo) =>
+			sourceTeams.map((team) =>
+				octokit.teams
+					.addOrUpdateRepoPermissionsInOrg({
+						org: owner,
+						team_slug: team.slug,
+						owner,
+						repo,
+						permission: team.permission as
+							| "pull"
+							| "triage"
+							| "push"
+							| "maintain"
+							| "admin",
+					})
+					.then(() => ({
+						repo,
+						team: team.name,
+						permission: team.permission,
+						success: true as const,
+					})),
+			),
+		),
+	);
+
+	return {
+		results: settled.map((r) =>
+			r.status === "fulfilled"
+				? r.value
+				: {
+						repo: "Unknown",
+						team: "Unknown",
+						permission: "Unknown",
+						success: false,
+						error: String(r.reason),
+					},
+		),
+	};
+}

--- a/apps/web/src/app/api/ai/command/route.ts
+++ b/apps/web/src/app/api/ai/command/route.ts
@@ -319,7 +319,182 @@ ${pageContextPrompt}`,
 				},
 			}),
 
-			// ─── Issue Actions ───────────────────────────────────────────────
+			// ─── Repo Team Actions ───────────────────────────────────────────
+		listRepoTeams: tool({
+			description:
+				"List teams with access to a repository. Returns a formatted table with team names and access levels.",
+			inputSchema: z.object({
+				owner: z
+					.string()
+					.describe("Organization or repository owner"),
+				repo: z.string().describe("Repository name"),
+			}),
+			execute: async ({ owner, repo }) => {
+				const { data } = await octokit.teams.listForRepo({
+					owner,
+					repo,
+					per_page: 100,
+				});
+				const permissionLabel = (p: string) => {
+					if (p === "pull") return "Read";
+					if (p === "push") return "Write";
+					return p.charAt(0).toUpperCase() + p.slice(1);
+				};
+				const teams = data.map((t) => ({
+					name: t.name,
+					slug: t.slug,
+					permission: permissionLabel(t.permission),
+					githubUrl: `https://github.com/orgs/${owner}/teams/${t.slug}`,
+				}));
+				const markdownTable =
+					teams.length === 0
+						? "_No teams have access to this repository._"
+						: `| Team | Access |\n|------|--------|\n` +
+							teams
+								.map(
+									(t) =>
+										`| [${t.name}](${t.githubUrl}) | ${t.permission} |`,
+								)
+								.join("\n");
+				return { teams, markdownTable };
+			},
+		}),
+
+		addTeamsToRepo: tool({
+			description:
+				"Add one or more teams to one or more repositories in an organization.",
+			inputSchema: z.object({
+				owner: z.string().describe("Organization name"),
+				repos: z
+					.array(z.string())
+					.describe("Target repository names"),
+				teams: z.array(
+					z.object({
+						slug: z.string().describe("Team slug"),
+						permission: z
+							.enum([
+								"pull",
+								"triage",
+								"push",
+								"maintain",
+								"admin",
+							])
+							.describe(
+								"Permission level: pull=read, push=write",
+							),
+					}),
+				),
+			}),
+			execute: async ({ owner, repos, teams }) => {
+				const results = await Promise.allSettled(
+					repos.flatMap((repo) =>
+						teams.map((team) =>
+							octokit.teams
+								.addOrUpdateRepoPermissionsInOrg({
+									org: owner,
+									team_slug: team.slug,
+									owner,
+									repo,
+									permission: team.permission,
+								})
+								.then(() => ({
+									repo,
+									team: team.slug,
+									success: true,
+								})),
+						),
+					),
+				);
+				const added = results
+					.filter((r) => r.status === "fulfilled")
+					.map((r) => (r as PromiseFulfilledResult<{ repo: string; team: string; success: boolean }>).value);
+				const errors = results
+					.filter((r) => r.status === "rejected")
+					.map((r) =>
+						String(
+							(r as PromiseRejectedResult).reason,
+						),
+					);
+				return { added, errors };
+			},
+		}),
+
+		copyRepoTeamAccess: tool({
+			description:
+				"Copy all team permissions from a source repository to one or more target repositories in the same organization.",
+			inputSchema: z.object({
+				owner: z.string().describe("Organization name"),
+				sourceRepo: z
+					.string()
+					.describe("Source repository to copy teams from"),
+				targetRepos: z
+					.array(z.string())
+					.describe("Target repositories to copy teams to"),
+			}),
+			execute: async ({ owner, sourceRepo, targetRepos }) => {
+				const { data: sourceTeams } =
+					await octokit.teams.listForRepo({
+						owner,
+						repo: sourceRepo,
+						per_page: 100,
+					});
+				if (sourceTeams.length === 0) {
+					return {
+						sourceTeams: [],
+						results: [],
+						message: `No teams found on ${owner}/${sourceRepo}.`,
+					};
+				}
+				const settled = await Promise.allSettled(
+					targetRepos.flatMap((repo) =>
+						sourceTeams.map((team) =>
+							octokit.teams
+								.addOrUpdateRepoPermissionsInOrg({
+									org: owner,
+									team_slug: team.slug,
+									owner,
+									repo,
+									permission: team.permission as
+										| "pull"
+										| "triage"
+										| "push"
+										| "maintain"
+										| "admin",
+								})
+								.then(() => ({
+									repo,
+									team: team.name,
+									permission: team.permission,
+									success: true,
+								})),
+						),
+					),
+				);
+				const results = settled.map((r) =>
+					r.status === "fulfilled"
+						? r.value
+						: {
+								repo: "Unknown",
+								team: "Unknown",
+								permission: "Unknown",
+								success: false,
+								error: String(
+									(r as PromiseRejectedResult).reason,
+								),
+							},
+				);
+				return {
+					sourceTeams: sourceTeams.map((t) => t.name),
+					results,
+					successCount: results.filter((r) => r.success)
+						.length,
+					errorCount: results.filter((r) => !r.success)
+						.length,
+				};
+			},
+		}),
+
+		// ─── Issue Actions ───────────────────────────────────────────────
 			createIssue: tool({
 				description:
 					"Create a new issue on a repository. Ask for title and body if not provided.",

--- a/apps/web/src/components/repo/copy-team-access-prompt.tsx
+++ b/apps/web/src/components/repo/copy-team-access-prompt.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { Loader2, CheckCircle, XCircle, Users } from "lucide-react";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogDescription,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { useMutationEvents } from "@/components/shared/mutation-event-provider";
+import { copyRepoTeamAccess } from "@/app/(app)/repos/team-actions";
+
+type CopyResult = {
+	repo: string;
+	team: string;
+	permission: string;
+	success: boolean;
+	error?: string;
+};
+
+export function CopyTeamAccessPrompt() {
+	const { subscribe } = useMutationEvents();
+
+	const [open, setOpen] = useState(false);
+	const [targetOwner, setTargetOwner] = useState("");
+	const [targetRepo, setTargetRepo] = useState("");
+	const [sourceRepo, setSourceRepo] = useState("");
+	const [results, setResults] = useState<CopyResult[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [isPending, startTransition] = useTransition();
+
+	// Keep a ref to avoid stale closure in the subscription
+	const pendingEvent = useRef<{ owner: string; repo: string } | null>(null);
+
+	useEffect(() => {
+		return subscribe((event) => {
+			if (event.type === "repo:created") {
+				pendingEvent.current = {
+					owner: event.owner,
+					repo: event.repo,
+				};
+				setTargetOwner(event.owner);
+				setTargetRepo(event.repo);
+				setSourceRepo("");
+				setResults(null);
+				setError(null);
+				setOpen(true);
+			}
+		});
+	}, [subscribe]);
+
+	function handleClose() {
+		setOpen(false);
+		setResults(null);
+		setError(null);
+		setSourceRepo("");
+	}
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		if (!sourceRepo.trim() || isPending) return;
+
+		startTransition(async () => {
+			const result = await copyRepoTeamAccess(
+				targetOwner,
+				sourceRepo.trim(),
+				[targetRepo],
+			);
+			setResults(result.results);
+		});
+	}
+
+	const successCount = results?.filter((r) => r.success).length ?? 0;
+	const errorCount = results?.filter((r) => !r.success).length ?? 0;
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle className="text-sm font-mono flex items-center gap-2">
+						<Users className="w-4 h-4" />
+						Copy team access
+					</DialogTitle>
+					<DialogDescription className="text-xs text-muted-foreground font-mono">
+						Copy team permissions from an existing repo to{" "}
+						<span className="text-foreground">
+							{targetOwner}/{targetRepo}
+						</span>
+					</DialogDescription>
+				</DialogHeader>
+
+				{results === null ? (
+					<form onSubmit={handleSubmit} className="space-y-4">
+						<div>
+							<label className="block text-[11px] font-mono text-muted-foreground mb-1">
+								Source repository
+							</label>
+							<input
+								type="text"
+								value={sourceRepo}
+								onChange={(e) => {
+									setSourceRepo(e.target.value);
+									setError(null);
+								}}
+								placeholder="template-repo"
+								className="w-full px-3 py-1.5 text-sm bg-background border border-border focus:border-foreground/30 focus:outline-none font-mono placeholder:text-muted-foreground"
+								autoFocus
+							/>
+							<p className="mt-1 text-[10px] font-mono text-muted-foreground">
+								Teams from this repo in{" "}
+								<span className="text-foreground">
+									{targetOwner}
+								</span>{" "}
+								will be copied to{" "}
+								<span className="text-foreground">
+									{targetRepo}
+								</span>
+							</p>
+						</div>
+
+						{error && (
+							<p className="text-xs text-destructive font-mono">
+								{error}
+							</p>
+						)}
+
+						<div className="flex gap-2">
+							<button
+								type="submit"
+								disabled={!sourceRepo.trim() || isPending}
+								className={cn(
+									"flex-1 flex items-center justify-center gap-2 px-4 py-2 text-xs font-mono border transition-colors cursor-pointer",
+									sourceRepo.trim() && !isPending
+										? "bg-foreground text-background border-foreground hover:bg-foreground/90"
+										: "bg-muted text-muted-foreground border-border cursor-not-allowed",
+								)}
+							>
+								{isPending ? (
+									<>
+										<Loader2 className="w-3 h-3 animate-spin" />
+										Copying…
+									</>
+								) : (
+									"Copy team access"
+								)}
+							</button>
+							<button
+								type="button"
+								onClick={handleClose}
+								disabled={isPending}
+								className="px-4 py-2 text-xs font-mono border border-border text-muted-foreground hover:text-foreground transition-colors cursor-pointer disabled:cursor-not-allowed"
+							>
+								Skip
+							</button>
+						</div>
+					</form>
+				) : (
+					<div className="space-y-3">
+						{/* Summary */}
+						<div className="flex items-center gap-3 text-xs font-mono">
+							{successCount > 0 && (
+								<span className="flex items-center gap-1 text-green-600 dark:text-green-400">
+									<CheckCircle className="w-3 h-3" />
+									{successCount} team
+									{successCount !== 1 ? "s" : ""} copied
+								</span>
+							)}
+							{errorCount > 0 && (
+								<span className="flex items-center gap-1 text-destructive">
+									<XCircle className="w-3 h-3" />
+									{errorCount} failed
+								</span>
+							)}
+							{results.length === 0 && (
+								<span className="text-muted-foreground">
+									No teams found on {sourceRepo}
+								</span>
+							)}
+						</div>
+
+						{/* Per-team results */}
+						{results.length > 0 && (
+							<ul className="space-y-1 max-h-48 overflow-y-auto">
+								{results.map((r, i) => (
+									<li
+										key={i}
+										className="flex items-center gap-2 text-[11px] font-mono"
+									>
+										{r.success ? (
+											<CheckCircle className="w-3 h-3 text-green-600 dark:text-green-400 shrink-0" />
+										) : (
+											<XCircle className="w-3 h-3 text-destructive shrink-0" />
+										)}
+										<span
+											className={cn(
+												r.success
+													? "text-foreground"
+													: "text-muted-foreground",
+											)}
+										>
+											{r.team}
+										</span>
+										{r.success && (
+											<span className="text-muted-foreground">
+												({r.permission})
+											</span>
+										)}
+										{r.error && (
+											<span className="text-destructive truncate">
+												— {r.error}
+											</span>
+										)}
+									</li>
+								))}
+							</ul>
+						)}
+
+						<button
+							type="button"
+							onClick={handleClose}
+							className="w-full px-4 py-2 text-xs font-mono border border-border text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+						>
+							Done
+						</button>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}


### PR DESCRIPTION
## Summary
This PR adds functionality to copy team permissions from one repository to another within the same organization. It includes a new UI component that prompts users to copy team access when a new repository is created, along with server-side actions and AI tool integrations.

## Key Changes

- **New Component**: `CopyTeamAccessPrompt` - A dialog component that appears after repository creation, allowing users to copy team permissions from an existing repository. Features include:
  - Form to specify source repository
  - Real-time feedback with success/error indicators
  - Per-team result display with permission levels
  - Graceful error handling

- **Server Actions**: New `team-actions.ts` file with three main functions:
  - `listRepoTeams()` - Fetch teams with access to a repository
  - `addTeamsToRepo()` - Add multiple teams to multiple repositories
  - `copyRepoTeamAccess()` - Copy all team permissions from source to target repositories

- **AI Tools**: Added three new tools to the AI command route:
  - `listRepoTeams` - List teams and their access levels for a repository
  - `addTeamsToRepo` - Add teams to repositories with specified permissions
  - `copyRepoTeamAccess` - Copy team access from source to target repositories

- **Integration**: Updated app layout to include the `CopyTeamAccessPrompt` component, which subscribes to `repo:created` mutation events

## Implementation Details

- Uses mutation event provider pattern to trigger the prompt when a new repository is created
- Handles concurrent operations with `Promise.allSettled()` for robust error handling
- Supports batch operations across multiple repositories and teams
- Provides detailed per-team feedback with GitHub URLs for teams
- Implements proper permission level mapping (pull→Read, push→Write, etc.)

https://claude.ai/code/session_01EoNgSxjdMomvP6da9zgKrf