### PR TITLE
fix: prevent horizontal scroll on large screens

### DIFF
--- a/apps/web/src/components/layout/nav-aware-content.tsx
+++ b/apps/web/src/components/layout/nav-aware-content.tsx
@@ -9,7 +9,7 @@ export function NavAwareContent({ children }: { children: React.ReactNode }) {
 	return (
 		<div
 			className={cn(
-				"flex flex-col lg:overflow-auto overflow-x-hidden transition-[margin-top,height] duration-200 ease-out",
+				"flex flex-col lg:overflow-auto overflow-x-hidden! transition-[margin-top,height] duration-200 ease-out",
 				isNavHidden
 					? "mt-0 lg:h-dvh"
 					: "mt-10 lg:h-[calc(100dvh-var(--spacing)*10)]",


### PR DESCRIPTION
Fixes #342

`lg:overflow-auto` is an overflow shorthand that resets both axes on large screens, overriding `overflow-x-hidden` and causing the horizontal scrollbar.

Changed to `overflow-x-hidden!` so it holds regardless of the shorthand.

**File:** `apps/web/src/components/layout/nav-aware-content.tsx`

```diff
- "flex flex-col lg:overflow-auto overflow-x-hidden transition-[margin-top,height] duration-200 ease-out"
+ "flex flex-col lg:overflow-auto overflow-x-hidden! transition-[margin-top,height] duration-200 ease-out"
```

https://github.com/user-attachments/assets/2b853c83-2351-44c9-b07f-12ad63f5f8d4