### PR TITLE
fix: add reaction display to inline review comments on diff tab

### DIFF
--- a/apps/web/src/components/pr/pr-diff-viewer.tsx
+++ b/apps/web/src/components/pr/pr-diff-viewer.tsx
@@ -56,6 +56,7 @@ import { useGlobalChatOptional } from "@/components/shared/global-chat-provider"
 import { MarkdownEditor, type MarkdownEditorRef } from "@/components/shared/markdown-editor";
 import type { ReviewThread, CheckStatus } from "@/lib/github";
 import { ClientMarkdown } from "@/components/shared/client-markdown";
+import { ReactionDisplay, type Reactions } from "@/components/shared/reaction-display";
 import { CheckStatusBadge } from "@/components/pr/check-status-badge";
 import { useMutationEvents } from "@/components/shared/mutation-event-provider";
 import { UserTooltip } from "@/components/shared/user-tooltip";
@@ -88,6 +89,7 @@ interface ReviewComment {
 	original_line: number | null;
 	side: string | null;
 	created_at: string;
+	reactions?: Reactions;
 }
 
 interface ReviewSummary {
@@ -3506,6 +3508,22 @@ function InlineCommentDisplay({
 					) : (
 						<div className="px-3 py-2 text-sm text-foreground/70">
 							<ClientMarkdown content={comment.body} />
+							{owner && repo && (
+								<div className="pt-1">
+									<ReactionDisplay
+										reactions={
+											comment.reactions ??
+											{}
+										}
+										owner={owner}
+										repo={repo}
+										contentType="pullRequestReviewComment"
+										contentId={
+											comment.id
+										}
+									/>
+								</div>
+							)}
 						</div>
 					)}
 				</>

--- a/apps/web/src/components/shared/reaction-display.tsx
+++ b/apps/web/src/components/shared/reaction-display.tsx
@@ -357,7 +357,12 @@ export function ReactionDisplay({
 
 	const getUsersForReaction = (key: string): ReactionWithId[] => {
 		if (!reactionUsers) return [];
-		return reactionUsers.filter((u) => u.content === key);
+		const seen = new Set<string>();
+		return reactionUsers.filter((u) => {
+			if (u.content !== key || seen.has(u.login)) return false;
+			seen.add(u.login);
+			return true;
+		});
 	};
 
 	const currentUserReactions = new Set(
@@ -425,15 +430,28 @@ export function ReactionDisplay({
 						content,
 					);
 					if (result.success && result.reactionId) {
-						setReactionUsers((prev) => [
-							...(prev ?? []),
-							{
-								id: result.reactionId!,
-								login: currentUser.login,
-								avatar_url: currentUser.avatar_url,
-								content,
-							},
-						]);
+						setReactionUsers((prev) => {
+							const existing = prev ?? [];
+							if (
+								existing.some(
+									(u) =>
+										u.login ===
+											currentUser.login &&
+										u.content ===
+											content,
+								)
+							)
+								return existing;
+							return [
+								...existing,
+								{
+									id: result.reactionId!,
+									login: currentUser.login,
+									avatar_url: currentUser.avatar_url,
+									content,
+								},
+							];
+						});
 					} else {
 						setOptimisticReactions((prev) => ({
 							...prev,


### PR DESCRIPTION
Fixes #345
Also fixes #347

Reactions were working on the Conversation tab but not on the Code (diff) tab.
The Code tab renders inline review comments inside `SingleFileDiff` → `InlineCommentDisplay` in `pr-diff-viewer.tsx`, but had no reaction UI wired up.

**Changes in `apps/web/src/components/pr/pr-diff-viewer.tsx`:**
- Imported `ReactionDisplay` and `Reactions` type from `@/components/shared/reaction-display`
- Added `reactions` field to the `ReviewComment` interface
- Rendered `<ReactionDisplay>` below each inline comment body, using `contentType="pullRequestReviewComment"`

**Changes in `apps/web/src/components/shared/reaction-display.tsx`:**
- Deduplicated users in `getUsersForReaction` to prevent duplicate avatars and React key warnings
- Added duplicate guard in optimistic update when adding a reaction

## Screenshots
### Before
<img src="https://github.com/user-attachments/assets/45802939-f522-465c-9e6b-9084f4bcc91e" width="800" />

### After
<img src="https://github.com/user-attachments/assets/43927266-27e8-45dc-814b-98af24a61737" width="800" />