### PR TITLE
fix: hide split diff toggle at lg breakpoint

### DIFF
--- a/apps/web/src/components/pr/pr-diff-viewer.tsx
+++ b/apps/web/src/components/pr/pr-diff-viewer.tsx
@@ -1925,7 +1925,7 @@ function SingleFileDiff({
 					<button
 						onClick={onToggleSplit}
 						className={cn(
-							"p-0.5 rounded transition-colors cursor-pointer shrink-0",
+							"hidden md:flex lg:hidden xl:flex p-0.5 rounded transition-colors cursor-pointer shrink-0",
 							splitView
 								? "bg-accent text-foreground"
 								: "text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent/60",


### PR DESCRIPTION
## Problem

Split diff view at the `lg` breakpoint (1024–1279px) is too cramped, the PR detail page has a resizable conversation panel alongside the diff panel, leaving each code column too narrow to read comfortably.

## Fix

Hide the split diff toggle button at the `lg` breakpoint only. It remains accessible at `md` (768–1023px) for wider tablet/landscape views and at `xl` (1280px+) for large desktop screens.

Breakpoint behaviour:
- xs/sm (< 768px) → hidden
- md (768–1023px) → visible  
- lg (1024–1279px) → hidden
- xl (1280px+) → visible

## Changes

- `apps/web/src/components/pr/pr-diff-viewer.tsx` - one class change on the split view toggle button