### PR TITLE
Fix personal GitHub cache sharing

### DIFF
--- a/IMPL-PHASE0-REPORT.md
+++ b/IMPL-PHASE0-REPORT.md
@@ -1,0 +1,170 @@
+# Phase 0 Implementation Report
+
+## Scope
+
+Implemented Phase 0 only: the ship-first shared-cache security fix for `ghpub:*`.
+Later phases from `PLAN-personal-github-cache.md` are not done.
+
+## Files Changed
+
+- `apps/web/src/lib/github-cache-policy.ts`
+  - New shared-cache policy module.
+  - Owns `isShareableCacheType`, `isUnsafeSharedCacheType`, and `isSharedCacheReadEnabled`.
+- `apps/web/src/lib/github.ts`
+  - Removed inline `SHAREABLE_CACHE_TYPES`.
+  - Imports shared-cache policy from `github-cache-policy.ts`.
+  - Keeps repo/org/viewer-sensitive data user-scoped.
+  - Honors `GITHUB_CACHE_SHARED_READ=0` for shared-cache read checks.
+- `apps/web/src/lib/github-cache-policy.test.ts`
+  - Adds Vitest coverage for allowlisted public types and former unsafe shared types.
+- `apps/web/scripts/purge-unsafe-shared-github-cache.ts`
+  - Adds one-time Redis cleanup utility for polluted unsafe `ghpub:*` keys.
+- `apps/web/.env.example`
+  - Documents `GITHUB_CACHE_SHARED_READ=1`.
+
+## Shared Cache Policy
+
+Allowlisted shared cache types:
+
+- `user_profile`
+- `user_public_orgs`
+- `user_events`
+- `trending_repos`
+
+Explicit unsafe guard:
+
+- Any cache type starting with `repo_`
+- Any cache type starting with `issue`
+- Any cache type starting with `pull_request`
+- Exact unsafe cache types:
+  - `repo`
+  - `org`
+  - `org_repos`
+  - `org_members`
+  - `repo_contents`
+  - `file_content`
+  - `notifications`
+  - `search_issues`
+  - `authenticated_user`
+  - `starred_repos`
+  - `contributions`
+  - `person_repo_activity`
+  - `pr_bundle`
+
+The policy intentionally does not deny by substring `org`; `user_public_orgs` remains shareable public metadata.
+
+`GITHUB_CACHE_SHARED_READ=0` skips shared-cache reads in both `readLocalFirstGitData` and the shared-refresh short-circuit in `enqueueGitDataSync`. Shared writes are still controlled only by the allowlist.
+
+## Cleanup Utility
+
+Utility:
+
+```bash
+cd apps/web
+bun run scripts/purge-unsafe-shared-github-cache.ts --dry-run
+bun run scripts/purge-unsafe-shared-github-cache.ts
+```
+
+Scans and deletes:
+
+- `ghpub:repo_*`
+- `ghpub:issue*`
+- `ghpub:pull_request*`
+- `ghpub:org:*`
+- `ghpub:org_repos:*`
+- `ghpub:org_members:*`
+- `ghpub:file_content:*`
+- `ghpub:repo_contents:*`
+
+It does not match `ghpub:user_public_orgs:*`.
+
+## Gate Output
+
+```text
+$ bun run typecheck
+$ bun -r exec tsc --noEmit
+Usage: bun exec <script>
+
+Execute a shell script directly from Bun.
+
+EXIT_CODE=0
+```
+
+```text
+$ bun run --workspaces typecheck
+@better-hub/web typecheck: Exited with code 0
+
+EXIT_CODE=0
+```
+
+```text
+$ bun run lint
+$ oxlint apps packages
+Found 62 warnings and 0 errors.
+Finished in 34ms on 469 files with 93 rules using 24 threads.
+
+EXIT_CODE=0
+```
+
+```text
+$ cd apps/web
+$ PATH=$PWD/../../node_modules/.bin:$PATH COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --config.verify-deps-before-run=ignore test -- --run
+$ vitest -- --run
+
+ RUN  v4.0.18 /home/shuv/.herdr/worktrees/better-hub/feat-personal-github-cache/apps/web
+
+ ✓ src/lib/github-cache-policy.test.ts (4 tests) 2ms
+ ✓ src/lib/extract-snippet.test.ts (31 tests) 5ms
+ ✓ src/app/(app)/repos/[owner]/[repo]/commits/actions.test.ts (1 test) 75ms
+
+ Test Files  3 passed (3)
+      Tests  36 passed (36)
+   Duration  165ms
+
+EXIT_CODE=0
+```
+
+Notes:
+
+- The repository root `bun run typecheck` script exits 0 but prints Bun `exec` usage in this environment, so `bun run --workspaces typecheck` was also run to perform the actual web typecheck.
+- Plain `cd apps/web && pnpm test` tried to bootstrap app-local pnpm dependencies and failed on pnpm ignored-build approval state. The final Vitest gate used the same app `test` script with pnpm's pre-run dependency verifier disabled and the root Bun workspace bin path on `PATH`.
+
+## Manual Validation Steps
+
+1. Run the cleanup dry-run:
+
+```bash
+cd apps/web
+bun run scripts/purge-unsafe-shared-github-cache.ts --dry-run
+```
+
+2. Run the cleanup for real:
+
+```bash
+cd apps/web
+bun run scripts/purge-unsafe-shared-github-cache.ts
+```
+
+3. Browse a private repository through the app, including repo chrome, issues, pull requests, branch/tree/file views, workflow runs, and nav counts.
+
+4. Confirm no new unsafe shared keys exist in Redis by scanning for:
+
+```text
+ghpub:repo_*
+ghpub:issue*
+ghpub:pull_request*
+ghpub:org:*
+ghpub:org_repos:*
+ghpub:org_members:*
+ghpub:file_content:*
+ghpub:repo_contents:*
+```
+
+5. Confirm user-scoped cache entries still populate under `gh:{userId}:*` for private repo data.
+
+6. Confirm `ghpub:user_public_orgs:*`, `ghpub:user_profile:*`, `ghpub:user_events:*`, and `ghpub:trending_repos:*` can still be used for public shared cache data.
+
+## Commits
+
+- `4170cf9 fix(github-cache): restrict shared cache policy`
+- Cleanup utility and this report are in the follow-up commit.

--- a/IMPL-PHASES-1-3-REPORT.md
+++ b/IMPL-PHASES-1-3-REPORT.md
@@ -1,0 +1,79 @@
+# IMPL Phases 1-3 Report
+
+## Scope
+
+Implemented Phases 1, 2, and 3 only from `PLAN-personal-github-cache.md` on branch `feat/personal-github-cache`.
+
+Phase 4 and later were not started.
+
+## Commits
+
+- Phase 1: `eba07cf feat(github-cache): add descriptors and freshness policy`
+- Phase 2: `003f1cb fix(github-cache): revive failed sync jobs`
+- Phase 3: included in the final commit with this report
+
+## Phase 1 - Cache Descriptors and Freshness Policy
+
+Added a typed descriptor registry for GitHub cache entries and moved cache key construction into one shared surface. The policy layer now derives shareability, freshness, and refresh behavior from descriptors instead of ad hoc cache-type checks.
+
+Files changed:
+- `apps/web/src/lib/github-cache-descriptors.ts`
+- `apps/web/src/lib/github-cache-descriptors.test.ts`
+- `apps/web/src/lib/github-cache-policy.ts`
+- `apps/web/src/lib/github-cache-policy.test.ts`
+- `apps/web/src/lib/github.ts`
+- `apps/web/src/lib/readme-cache.ts`
+- `apps/web/src/lib/repo-data-cache.ts`
+
+Gate after Phase 1:
+- `bun run typecheck`: passed, but the root script only prints Bun exec usage in this environment
+- `bun run --workspaces typecheck`: passed
+- `bun run lint`: passed with existing warnings only
+- `apps/web vitest`: passed, 4 files and 41 tests
+
+## Phase 2 - Failed Sync Job Requeue
+
+Updated GitHub sync job enqueueing so retryable failed jobs are revived instead of permanently blocking future cache refreshes for the same user/dedupe key. Pending jobs are refreshed with latest payload and due time; running jobs are left untouched.
+
+Files changed:
+- `apps/web/src/lib/github-sync-store.ts`
+- `apps/web/src/lib/github-sync-store.test.ts`
+
+Gate after Phase 2:
+- `bun run typecheck`: passed, but the root script only prints Bun exec usage in this environment
+- `bun run --workspaces typecheck`: passed
+- `bun run lint`: passed with existing warnings only
+- `apps/web vitest`: passed, 5 files and 46 tests
+
+## Phase 3 - Worker Auth Context and Repo Events Local-First Cache
+
+Extracted GitHub auth context resolution into a reusable module that can resolve request-session auth or decrypt the latest stored GitHub account token for a specific user. The helper avoids logging token material and tolerates profile lookup failures by returning a usable Octokit context.
+
+The existing `github.ts` request path now imports the shared request auth context and exposes worker-friendly auth injection for local-first GitHub reads. Repo events now use the local-first cache/sync path and include a `repo_events` sync job type.
+
+No Inngest worker was present in the current codebase, so there was no worker entrypoint to wire in this phase. `resolveGitHubAuthContextForUser` and `fetchAndCacheRepoPageDataWithAuth` are ready for later worker phases.
+
+Files changed:
+- `apps/web/src/lib/github-auth-context.ts`
+- `apps/web/src/lib/github-auth-context.test.ts`
+- `apps/web/src/lib/github.ts`
+- `IMPL-PHASES-1-3-REPORT.md`
+
+Final Phase 3 gate:
+- `bun run typecheck`: passed, but the root script only prints Bun exec usage in this environment
+- `bun run --workspaces typecheck`: passed
+- `bun run lint`: passed with existing warnings only
+- `apps/web vitest`: passed, 6 files and 49 tests
+
+Final Vitest result:
+```
+Test Files  6 passed (6)
+Tests  49 passed (49)
+```
+
+## Notes
+
+The app-local pnpm bootstrap can create `apps/web/node_modules`, `apps/web/pnpm-lock.yaml`, and `apps/web/pnpm-workspace.yaml`, which cause Better Auth type skew in this worktree. Those generated app-local artifacts were removed before gates. The apps/web Vitest gate was run from `apps/web` with the root workspace bin path and `--config.verify-deps-before-run=ignore`.
+
+No push was performed.
+

--- a/PLAN-personal-github-cache.md
+++ b/PLAN-personal-github-cache.md
@@ -1,0 +1,681 @@
+# Personal GitHub Cache Plan
+
+> **Revisions (2026-06-23):** Revised after plan review. This version keeps Phase 0 as the first shippable security fix, aligns warm stages with the cache stores the UI actually reads, makes lock ownership single-runId based across API → Inngest worker, specifies a concrete background GitHub auth-context resolver, repairs Prisma sync-job dedupe so failed rows do not block future refreshes, makes repo events a real cached warm target, adds a central cache descriptor/key-builder map, includes polluted `ghpub:*` cleanup, structured warm-run logs, and requires new cache env vars in `apps/web/.env.example`. **Second pass:** makes the README HTML read seam explicitly cache-first so warmed `readme_html:*` is used on first navigation, clarifies auth-injected paths must use lower-level helpers instead of React `cache()` wrappers, fixes repo-page-entry/status phase ordering, and defines quick/full ownership for layout metadata caches (languages, contributors, branches, tags).
+>
+> **Prior revision (2026-03-23):** Updated after codebase review (`~/.agent/diagrams/better-hub-personal-github-cache-plan-review.html`). Changes: Phase 0 security first, shared-cache severity corrected, warm execution split (sync dev vs Inngest prod), lock/coordination rules, repo-page-data versioning, warm-stage fixes, explicit stage→data-class map.
+
+## Context
+
+Better Hub is being used for a small, trusted set of personal repositories. The goal is to make repository navigation feel local-first: repo lists, repo chrome, PRs, issues, README, file tree, CI, and activity should load from a warm cache with GitHub refreshes happening in the background.
+
+The existing codebase already has most of the right primitives:
+
+- `apps/web/src/lib/github.ts` contains the primary GitHub access module and most pages already call through it.
+- `apps/web/src/lib/github.ts` has `readLocalFirstGitData`, which returns cached data, enqueues a refresh, and drains sync jobs opportunistically.
+- `apps/web/src/lib/github-sync-store.ts` stores user-scoped GitHub cache entries in Redis and has a Prisma-backed sync-job queue.
+- `apps/web/src/lib/repo-data-cache.ts` has Redis helpers for repo page data, file trees, overview PRs/issues/events/CI, branches, tags, languages, and contributors.
+- `apps/web/prisma/schema.prisma` already defines `GithubCacheEntry`, but the table is currently unused by `github-sync-store.ts`; cache entries are Redis-only.
+- `apps/web/src/lib/inngest.ts` exists and can run long-running work outside HTTP request timeouts.
+- Repo pages already use cached fragments and background revalidation through:
+  - `apps/web/src/app/(app)/repos/[owner]/[repo]/layout.tsx`
+  - `apps/web/src/app/(app)/repos/[owner]/[repo]/page.tsx`
+  - `apps/web/src/components/repo/repo-revalidator.tsx`
+  - `apps/web/src/app/(app)/repos/[owner]/[repo]/revalidate-actions.ts`
+  - `apps/web/src/app/(app)/repos/[owner]/[repo]/overview-actions.ts`
+
+Build a first-class personal cache warmer on top of these seams, not a parallel GitHub client.
+
+## Goals
+
+- [ ] Keep all personal repositories discoverable and warm after sign-in.
+- [ ] Make first navigation to a warmed repo return cached data quickly.
+- [ ] Refresh hot repo data in the background without blocking page loads.
+- [ ] Keep stale data available when GitHub is slow, rate-limited, or temporarily unavailable.
+- [ ] **Eliminate cross-user private-repo leakage via `ghpub:*` shared cache (pre-existing bug).**
+- [ ] Provide observability: cache status, job backlog, last refresh time, failure details, and structured warm-run logs.
+- [ ] Local-dev friendly by default; production warm path must not rely on a single long HTTP request.
+- [ ] Document cache policy and operational notes in project `AGENTS.md` when behavior ships.
+
+## Non-Goals
+
+- [ ] Do not build a full GitHub data mirror in V1.
+- [ ] Do not require OAuth App setup; the current PAT sign-in path should work.
+- [ ] Do not add webhooks in V1.
+- [ ] Do not make GitHub mutation paths cache-first. Writes hit GitHub, then invalidate or refresh affected keys.
+- [ ] Do not cache raw token values or log PATs.
+- [ ] Do not run unbounded synchronous warm (hundreds of GitHub calls) inside a serverless HTTP handler in production.
+- [ ] Do not import app-route Server Action modules into `lib` warmer code; extract shared library helpers and let Server Actions delegate to them.
+
+## Important Current-State Findings
+
+### Existing Local-First Read Path
+
+`readLocalFirstGitData` in `apps/web/src/lib/github.ts`:
+
+- returns user-scoped cached data if available,
+- enqueues a refresh job,
+- checks shared cache for allowlisted data,
+- falls back to synchronous GitHub fetch on a miss,
+- falls back to default data if GitHub fails.
+
+This is the correct seam for most GitHub API response caches.
+
+### Repo Page Data Is Cached Separately
+
+`getRepoPageData` reads `repo_page_data:{userId}:{owner}/{repo}` via `repo-data-cache.ts`. The Redis key currently uses `ex: 3600` (1 hour). When it expires, the key is gone and the next request blocks on `fetchRepoPageDataGraphQL`.
+
+For a personal repo cache, this should become stale-while-revalidate rather than expire-to-cold.
+
+### Redis Is the Real Cache Store Today
+
+`GithubCacheEntry` exists in Prisma (table created in `20260220141241_init`), but `getGithubCacheEntry` / `upsertGithubCacheEntry` are Redis-only.
+
+V1 stays Redis-only. Phase 12 (optional) adds Postgres read-through without a new migration.
+
+Local dev: app uses Upstash REST (`@upstash/redis`) → `serverless-redis-http` → Docker `better-hub-redis`. `redis-cli` against the Docker container inspects the same data.
+
+### Shared Cache — Active Security Issue (not “personal-only”)
+
+The comment above `SHAREABLE_CACHE_TYPES` (`github.ts` ~97–102) says repo data is excluded from the shared cache. **The set contradicts the comment:** it includes `repo_issues`, `repo_pull_requests`, `issue`, `issue_comments`, `pull_request`, `pull_request_files`, `pull_request_comments`, `pull_request_reviews`, `repo_branches`, `repo_tags`, `repo_releases`, `repo_contributors`, `repo_workflow_runs`, `repo_nav_counts`, `org`, `org_members`, and more.
+
+`upsertCacheWithShared` writes those types to `ghpub:{cacheKey}` where cache keys are owner/repo scoped without `userId` (for example `repo_issues:owner/repo:open`). Any user who hits `readLocalFirstGitData`’s shared-cache branch can receive another user’s cached private-repo payload without a GitHub permission check.
+
+**This is live in any multi-user deployment. Phase 0 ships first and is deployable alone. Do not defer it because usage is “personal.”**
+
+### The UI Reads Multiple Cache Families
+
+The warmer must populate the cache stores that the first navigation path actually reads:
+
+- Repo layout reads `repo_page_data:{userId}:...` and owner-scoped `repo_file_tree:{owner}/{repo}` before falling back to `getRepoTree(owner, repo, defaultBranch, true)`.
+- Repo overview currently calls `revalidateReadme(owner, repo, defaultBranch)` synchronously, while rendered README HTML is stored under `readme_html:{owner}/{repo}`. V1 must make this read seam cache-first: either `page.tsx` reads `getCachedReadmeHtml` first and schedules a background refresh, or `revalidateReadme` delegates to a shared cache-first helper that only blocks on GitHub on a true miss.
+- Repo overview also reads `overview_prs`, `overview_issues`, `overview_events`, `overview_commit_activity`, and `overview_ci` owner-scoped caches.
+- The code page reads `getRepoReadme(owner, repo, defaultBranch)` for the raw README response.
+- Actions pages read `getRepoWorkflowRuns`.
+
+Therefore, V1 warm stages must not only call `readLocalFirstGitData` functions; they must also populate the owner-scoped UI fragment caches where the UI already reads them. If a future refactor makes the UI read only user-scoped `gh:{userId}:*` entries, that can become a follow-up simplification.
+
+### Background Auth Is Not Available Through Request Helpers
+
+`getGitHubAuthContext` in `github.ts` is request-header/session based and private. An Inngest worker with only `{ userId }` cannot call the current `getRepo*` functions successfully because they fall back to unauthenticated data without request headers.
+
+V1 must extract an explicit GitHub auth-context resolver for background jobs and make warmer-used GitHub functions accept an injected auth context.
+
+### Prisma Sync-Job Dedupe Can Block Future Refreshes
+
+`GithubSyncJob` has a unique `(userId, dedupeKey)` constraint and `enqueueGithubSyncJob` currently upserts with `update: {}`. A permanently `failed` row can block future refresh attempts for the same dedupe key.
+
+V1 must repair this so enqueueing a deduped refresh revives or updates failed rows instead of silently doing nothing.
+
+### Coordination Layers (document precedence)
+
+V1 will use several mechanisms. Document this at the top of `github-cache-warmer.ts`:
+
+1. **Redis user warm lock** (`github-cache-warm-lock:{userId}`) — only one active warm run per user.
+2. **Run ID lease** — a `runId` is generated by the API and passed to Inngest; lock release only happens if Redis still stores that same `runId`.
+3. **Prisma `GithubSyncJob` dedupe** — one refresh row per `userId` + `dedupeKey`, with failed-row revival.
+4. **Browser localStorage / BroadcastChannel** — avoid duplicate client triggers across tabs.
+5. **Optional per-repo warm throttle** (`github-cache-warm-repo:{userId}:{owner}/{repo}`) — skip if warmed recently when `refreshStaleOnly: true`. Defer to V1.1 if Prisma dedupe + user lock are sufficient.
+
+Precedence: if user lock is held, API returns `already-running` and does not start work. Client throttle only prevents starting a POST; it does not override the server lock.
+
+## Target Architecture
+
+### New / changed modules
+
+| Module | Role |
+| --- | --- |
+| `apps/web/src/lib/github-auth-context.ts` | Request and background GitHub auth-context resolution; no token logging. |
+| `apps/web/src/lib/github-cache-descriptors.ts` | Stable cache-key builders, cache type → data class map, UI fragment keys, and shareability metadata. |
+| `apps/web/src/lib/github-cache-policy.ts` | Freshness policies plus the shared-cache allowlist/deny guard, backed by descriptors. |
+| `apps/web/src/lib/github-cache-warmer.ts` | Discovery, staged warm, result aggregation, structured logs. Accepts auth context and an existing lock lease; does not acquire a second lock for API/Inngest runs. |
+| `apps/web/src/lib/repo-overview-cache-warmer.ts` | Shared server-side helpers for rendered README, overview PRs/issues/events/CI, commit activity, and layout file-tree cache. Server Actions delegate to these helpers. |
+| `apps/web/src/lib/github-cache-status.ts` | Introspection without GitHub calls, using descriptors instead of duplicating private key builders. |
+| `apps/web/src/app/api/github-cache/warm/route.ts` | Authenticated trigger. Generates `runId`, acquires lock, runs inline in dev or sends Inngest event in production. |
+| `apps/web/src/components/github-cache/github-cache-warmer.tsx` | Client trigger (gated). |
+
+### Auth context contract
+
+Add an explicit `GitHubAuthContext` module and make warmer-used functions accept an injected context.
+
+Required behavior:
+
+- Request path: `getRequestGitHubAuthContext()` keeps existing behavior from `getServerSession()` + request headers.
+- Background path: `resolveGitHubAuthContextForUser(userId)`:
+  - reads the user’s GitHub `Account` row (`providerId = "github"`) from Prisma,
+  - decrypts `account.accessToken` with Better Auth’s symmetric decrypt utility and `BETTER_AUTH_SECRET`, matching how PAT sign-in and `encryptOAuthTokens` store tokens,
+  - creates an `Octokit({ auth: token })`,
+  - optionally fetches `/user` to populate `githubUser`, but does not fail the warm solely because profile lookup is rate-limited,
+  - never logs, returns, or stores the raw token outside the in-memory auth context.
+- Refactor only the GitHub functions used by the warmer to accept an optional auth override first. Existing call sites remain unchanged and fall back to request context.
+- Auth-injected/background paths must use lower-level helpers, not React `cache()` wrappers such as the current `getRepoPageData` export. Expose lower-level `*WithAuth`/helper functions for background use so React request memoization cannot capture request-only auth or headers.
+- If background auth cannot resolve a token, the Inngest function records a failed warm result (`stage: "auth"`, `message: "github-token-unavailable"`), releases the lock by matching `runId`, and exits.
+
+### Central cache descriptors
+
+Do not let status, warmer, and tests reimplement private cache-key builders from `github.ts`.
+
+Add descriptors for at least these V1 cache families:
+
+- GitHub response caches: `user_repos`, `user_orgs`, `org_repos`, `repo`, `repo_tree`, `repo_readme`, `repo_issues`, `repo_pull_requests`, `repo_events`, `repo_workflow_runs`, `repo_branches`, `repo_tags`, `repo_releases`, `repo_contributors`, `repo_discussions`, `repo_nav_counts`, `repo_languages`.
+- UI fragment caches: `repo_page_data`, `repo_file_tree`, `readme_html`, `overview_prs`, `overview_issues`, `overview_events`, `overview_commit_activity`, `overview_ci`.
+- Shared public caches: `user_profile`, `user_public_orgs`, `user_events`, `trending_repos`.
+
+Descriptor responsibilities:
+
+- build the exact Redis key used by producers/consumers,
+- identify the data class,
+- indicate whether the cache is user-scoped, owner/repo-scoped, or shared-public,
+- indicate whether `ghpub:*` sharing is allowed,
+- provide a single source for status UI and regression tests.
+
+`github.ts` private builder functions should be replaced or wrapped by descriptor calls as they are touched. V1 must at least centralize every key the warmer/status/test suite uses.
+
+### Warmer public API
+
+The warmer should not discover auth from request globals and should not acquire a second user lock when invoked from the API/Inngest path.
+
+```ts
+export type GithubCacheWarmMode = "quick" | "full";
+
+export interface GithubCacheWarmOptions {
+  mode: GithubCacheWarmMode;
+  maxRepos?: number;
+  maxConcurrentRepos?: number;
+  refreshStaleOnly?: boolean;
+}
+
+export interface GithubCacheWarmRun {
+  runId: string;
+  source: "api-inline" | "inngest" | "debug" | "script";
+  lockKey: string;
+  lockAlreadyHeld: true;
+}
+
+export interface GithubCacheWarmResult {
+  userId: string;
+  runId: string;
+  source: GithubCacheWarmRun["source"];
+  discoveredRepos: number;
+  selectedRepos: number;
+  warmedRepos: number;
+  skippedRepos: number;
+  failedRepos: number;
+  jobsQueued: number;
+  durationMs: number;
+  skippedReason?: "already-running" | "disabled" | "throttled" | "auth-unavailable" | "lock-lost";
+  errors: Array<{ repo: string; stage: string; message: string }>;
+}
+
+export async function warmPersonalGithubCache(params: {
+  authCtx: GitHubAuthContext;
+  options: GithubCacheWarmOptions;
+  run: GithubCacheWarmRun;
+}): Promise<GithubCacheWarmResult>;
+```
+
+Script-only callers may use a small wrapper that acquires the lock before calling `warmPersonalGithubCache`; the core warmer should still receive an explicit `runId` lease.
+
+### Cache policy module
+
+```ts
+export type GithubCacheDataClass =
+  | "repo-chrome"
+  | "repo-inventory"
+  | "hot-list"
+  | "ci"
+  | "activity"
+  | "code-tree"
+  | "readme"
+  | "stats"
+  | "identity";
+
+export interface GithubCachePolicy {
+  freshForMs: number;
+  refreshAfterMs: number;
+  expireAfterMs: number | null;
+}
+
+export function getGithubCachePolicy(dataClass: GithubCacheDataClass): GithubCachePolicy;
+export function isFresh(syncedAt: string | null, dataClass: GithubCacheDataClass): boolean;
+export function shouldRefresh(syncedAt: string | null, dataClass: GithubCacheDataClass): boolean;
+
+/** Types safe for ghpub:* — allowlist only; no repo-scoped or viewer-specific data. */
+export function isShareableCacheType(cacheType: string): boolean;
+```
+
+Policy defaults (V1: prefer stale over empty; `expireAfterMs: null`):
+
+| Data class | Examples | Fresh for | Refresh after |
+| --- | --- | ---: | ---: |
+| `hot-list` | open PRs, open issues, discussions | 1 min | 2 min |
+| `ci` | workflow runs, check status | 30 sec | 1 min |
+| `activity` | repo events | 2 min | 5 min |
+| `repo-chrome` | repo page GraphQL bundle, nav counts | 10 min | 30 min |
+| `code-tree` | layout file tree, default branch tree, branches, tags | 15 min | 60 min |
+| `readme` | README raw response, rendered README HTML | 15 min | 60 min |
+| `stats` | languages, contributors, commit activity | 6 hr | 24 hr |
+| `repo-inventory` | user repos, org repos | 5 min | 15 min |
+| `identity` | authenticated user, public user profile/orgs | 15 min | 60 min |
+
+### Warm stage → data class → cache target map
+
+Use this in the warmer and in status UI; do not infer ad hoc.
+
+| Warm stage | Data class | Cache target(s) | Notes |
+| --- | --- | --- | --- |
+| `fetchAndCacheRepoPageData` | `repo-chrome` | `repo_page_data:{userId}:...`; `gh:{userId}:repo_nav_counts:*`; `gh:{userId}:repo_languages:*` | Store v2 envelope for `repo_page_data`. |
+| `warmRepoFileTreeForLayout` | `code-tree` | `repo_file_tree:{owner}/{repo}` and `gh:{userId}:repo_tree:{owner}/{repo}:{defaultBranch}:1` | Use `defaultBranch` in V1 because layout fallback asks by branch name, not commit SHA. Do not warm only by SHA unless layout is refactored. |
+| `warmRenderedReadmeHtml` | `readme` | `readme_html:{owner}/{repo}` | Extract shared cache-first helper from `readme-actions.ts`; `page.tsx`/Server Action delegates to it so warmed HTML is used before any GitHub fetch. |
+| `getRepoReadme(owner, repo, defaultBranch)` | `readme` | `gh:{userId}:repo_readme:*` | Optional quick-stage if code page should be warm too; avoid duplicate GitHub fetch if rendered helper can reuse raw content. |
+| `warmOverviewPRs` | `hot-list` | `overview_prs:{owner}/{repo}` plus `gh:{userId}:repo_pull_requests:*` | Shared helper delegates to `getRepoPullRequests`. |
+| `warmOverviewIssues` | `hot-list` | `overview_issues:{owner}/{repo}` plus `gh:{userId}:repo_issues:*` | Shared helper filters PRs as overview does today. |
+| `warmOverviewEvents` | `activity` | `overview_events:{owner}/{repo}` plus `gh:{userId}:repo_events:*` | Add real cached `getRepoEvents` wrapper in `github.ts` with `cacheType: "repo_events"`. |
+| `warmOverviewCIStatus` | `ci` | `overview_ci:{owner}/{repo}` | Uses `fetchCheckStatusForRef`; also call `getRepoWorkflowRuns` when warming Actions page. |
+| `getRepoWorkflowRuns` | `ci` | `gh:{userId}:repo_workflow_runs:*` | Keeps Actions page/API warm. |
+| `warmLayoutMetadataQuick` | `code-tree` / `stats` | owner-scoped `repo_languages:*`, `repo_branches:*`, `repo_tags:*`, `repo_contributor_avatars:*` | Quick mode; supports layout/sidebar first paint. |
+| `getRepoBranches` / `getRepoTags` | `code-tree` | `gh:{userId}:repo_branches:*`, `gh:{userId}:repo_tags:*`; owner-scoped `repo_branches:*`, `repo_tags:*` | Quick warms owner-scoped layout caches; full also refreshes user-scoped response caches. |
+| `getRepoReleases` | `code-tree` | `gh:{userId}:repo_releases:*` | Full mode. |
+| `getRepoContributors` | `stats` | `gh:{userId}:repo_contributors:*`; owner-scoped `repo_contributor_avatars:*` | Quick warms sidebar avatar cache; full also refreshes user-scoped contributor response cache. |
+| `warmOverviewCommitActivity` | `stats` | `overview_commit_activity:{owner}/{repo}` | It persists overview cache. Do not call raw `getCommitActivity` without writing a cache. |
+| `getRepoDiscussionsPage` | `hot-list` | `gh:{userId}:repo_discussions:*` | Full mode when discussions enabled. |
+| `getUserRepos` / `getUserOrgs` / `getOrgRepos` | `repo-inventory` | `gh:{userId}:user_repos:*`, `gh:{userId}:user_orgs:*`, `gh:{userId}:org_repos:*` | Discovery only; not shareable. |
+
+### Warm execution model
+
+| Environment | Behavior |
+| --- | --- |
+| **Local dev** | `POST /api/github-cache/warm` validates session, resolves request auth, generates `runId`, acquires the Redis user lock, runs `warmPersonalGithubCache` inline when `GITHUB_CACHE_WARM_INLINE=1` or `NODE_ENV=development`, then releases by matching `runId`. |
+| **Production** | Route validates session, generates `runId`, acquires the Redis user lock, sends Inngest event `github/cache.warm` with `{ userId, runId, lockKey, options }`, and returns `{ accepted: true, runId }` immediately. Worker verifies lock value equals `runId`, resolves background auth, runs warmer, stores result, and releases by matching `runId`. |
+| **Client** | `github-cache-warmer.tsx` mounts only when `NEXT_PUBLIC_GITHUB_CACHE_WARM_ENABLED=1`; production should keep this off until Inngest + background auth are verified and `GITHUB_CACHE_WARM_PROD_ENABLED=1`. |
+
+Never hold a 10-minute Redis lock across a dead serverless request without crash protection. Use lock TTL for crash safety and release in `finally` only via compare-and-delete.
+
+### Lock acquire / verify / renew / release
+
+API is the sole lock acquirer for API-triggered runs. The worker/core warmer must not call `SET NX` again for the same run.
+
+Required lock helpers:
+
+- `acquireGithubCacheWarmLock(userId, runId, ttlSeconds)` → `SET github-cache-warm-lock:{userId} runId NX EX ttlSeconds`
+- `verifyGithubCacheWarmLock(userId, runId)` → `GET lockKey === runId`
+- `renewGithubCacheWarmLock(userId, runId, ttlSeconds)` → compare value and extend TTL only if value matches
+- `releaseGithubCacheWarmLock(userId, runId)` → atomic compare-and-delete only if value matches
+
+Release must be atomic. Use Redis Lua / Upstash `eval` equivalent:
+
+```lua
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+```
+
+If the worker starts and the lock value is missing or different, it records `skippedReason: "lock-lost"` and exits without warming.
+
+### Warm-run telemetry contract
+
+Structured logs are required from the first implementation:
+
+- `github_cache_warm.requested` — `userId`, `runId`, `mode`, `source`, `maxRepos`, `refreshStaleOnly`.
+- `github_cache_warm.lock_acquired` / `already_running` / `lock_lost` — `userId`, `runId`, `lockKey`, `ttlSeconds`.
+- `github_cache_warm.started` — `userId`, `runId`, `mode`, `selectedRepos`, `discoveredRepos`.
+- `github_cache_warm.stage_completed` — `userId`, `runId`, `repo`, `stage`, `durationMs`, `cacheTargets`.
+- `github_cache_warm.stage_failed` — `userId`, `runId`, `repo`, `stage`, `errorClass`, `message`.
+- `github_cache_warm.completed` — `userId`, `runId`, counts, `durationMs`, `errorCount`.
+
+Never log PATs, decrypted access tokens, response payloads, or raw request bodies. Repo names are acceptable for local/dev logs; if production logs are exported externally, hash `owner/repo` or make repo-name logging debug-only.
+
+## Implementation Plan
+
+### Phase 0: Fix shared cache safety and purge polluted keys (ship first)
+
+**Target:** `apps/web/src/lib/github-cache-policy.ts`, `apps/web/src/lib/github-cache-descriptors.ts`, `apps/web/src/lib/github.ts`, one-time cleanup utility/script.
+
+- [ ] Move shareability decisions out of inline `github.ts` into policy/descriptors.
+- [ ] Use an **allowlist** for shareable types. Initial shareable set:
+  - `user_profile`
+  - `user_public_orgs`
+  - `user_events`
+  - `trending_repos`
+- [ ] Add an explicit unsafe guard for repo/viewer-scoped families:
+  - any `cacheType` starting with `repo_`,
+  - any `cacheType` starting with `issue`,
+  - any `cacheType` starting with `pull_request`,
+  - exact org-scoped/viewer-sensitive types: `org`, `org_repos`, `org_members`,
+  - `repo_contents`, `file_content`, `notifications`, `search_issues`, `authenticated_user`, `starred_repos`, `contributions`, `person_repo_activity`, `pr_bundle`.
+- [ ] **Deny-list wording:** do not deny by substring `org`; `user_public_orgs` is intentionally kept because it is public user metadata. Deny exact org-scoped cache types instead.
+- [ ] Replace inline `isShareableCacheType` in `github.ts` with import from policy/descriptors.
+- [ ] Fix the misleading SECURITY comment to match the allowlist.
+- [ ] Add optional `GITHUB_CACHE_SHARED_READ=0` to skip the shared-cache read branch during rollback/emergency response.
+- [ ] Add a one-time polluted-key cleanup utility or documented admin command that scans/deletes unsafe shared keys, including:
+  - `ghpub:repo_*`
+  - `ghpub:issue*`
+  - `ghpub:pull_request*`
+  - `ghpub:org:*`
+  - `ghpub:org_repos:*`
+  - `ghpub:org_members:*`
+  - `ghpub:file_content:*`
+  - `ghpub:repo_contents:*`
+- [ ] Unit test: no repo-scoped type is shareable; regression test listing former bad types.
+- [ ] Manual validation: browse a private repo and confirm no new unsafe `ghpub:*` keys appear.
+
+**Rollback:** shrinking writes is safe and preferred. `GITHUB_CACHE_SHARED_READ=0` is only for temporarily skipping shared reads if unexpected behavior appears.
+
+**Validation:**
+
+- [ ] Private repo issue/PR/tree/branch/workflow/nav data is never written to `ghpub:*`.
+- [ ] User-scoped `gh:{userId}:*` behavior unchanged.
+- [ ] Existing polluted `ghpub:repo_*` / `ghpub:issue*` / `ghpub:pull_request*` keys are purged or allowed to expire with a documented verification scan.
+
+### Phase 1: Cache descriptors and freshness policy
+
+**Targets:** `github-cache-descriptors.ts`, `github-cache-policy.ts`, `github.ts` key-builder call sites touched by the warmer/status.
+
+- [ ] Implement central descriptors for V1 GitHub response caches and UI fragment caches.
+- [ ] Export stable key-builder functions from descriptors; warmer/status/tests must use these instead of duplicating string formats.
+- [ ] Refactor the touched private builders in `github.ts` to call descriptors or share the same builder implementation.
+- [ ] Implement `getGithubCachePolicy`, `isFresh`, `shouldRefresh` in `github-cache-policy.ts`.
+- [ ] Unit tests for policy table and descriptor key stability.
+- [ ] Do not wire freshness decisions into every call site yet; use descriptors first for Phase 0, warmer, status, and tests.
+
+### Phase 2: Repair Prisma sync-job dedupe semantics
+
+**Target:** `apps/web/src/lib/github-sync-store.ts`.
+
+- [ ] Change `enqueueGithubSyncJob` so a pre-existing failed row does not block future refreshes.
+- [ ] Desired behavior:
+  - missing row: create pending job as today,
+  - existing `failed`: reset to `pending`, `attempts = 0`, `lastError = null`, update `payloadJson`, `nextAttemptAt = now`, `updatedAt = now`,
+  - existing `pending`: update `payloadJson` and `updatedAt`; ensure `nextAttemptAt` is not pushed later than now for an explicit refresh,
+  - existing `running`: leave it alone unless the existing timeout recovery marks it pending.
+- [ ] Keep the `(userId, dedupeKey)` unique constraint.
+- [ ] Add tests for failed-row revival, pending-row update, and concurrent insert race handling.
+
+### Phase 3: Extract GitHub auth context for request + background execution
+
+**Targets:** `github-auth-context.ts`, `github.ts`, warmer-used GitHub functions.
+
+- [ ] Move `GitHubAuthContext` into an exported module.
+- [ ] Implement request resolver by preserving current `getServerSession()` + header force-refresh behavior.
+- [ ] Implement background resolver using Prisma `Account` + Better Auth symmetric decrypt with `BETTER_AUTH_SECRET`.
+- [ ] Refactor warmer-used functions to accept an optional auth override through lower-level non-React-cache helpers:
+  - discovery: `getUserRepos`, `getUserOrgs`, `getOrgRepos`,
+  - repo chrome: `fetchAndCacheRepoPageDataWithAuth` / lower-level page-data helpers; do not call the React `cache()`-wrapped `getRepoPageData` from background auth-injected paths,
+  - tree/readme/hot lists: `getRepoTree`, `getRepoReadme`, `getRepoPullRequests`, `getRepoIssues`,
+  - CI/activity/stats: `getRepoWorkflowRuns`, cached `getRepoEvents`, `getRepoBranches`, `getRepoTags`, `getRepoReleases`, `getRepoContributors`, `getRepoDiscussionsPage`, `getCommitActivity` if persisted by a warmer helper.
+- [ ] Existing UI call sites should keep working without passing auth.
+- [ ] Inngest worker must use `resolveGitHubAuthContextForUser(userId)` and pass the resulting `authCtx` into the warmer.
+- [ ] Add tests with mocked encrypted account token; no real token in fixtures.
+
+### Phase 4: Repo page data stale-available
+
+**Targets:** `repo-data-cache.ts`, `repo-data-cache-vc.ts`, `github.ts`, `updateCachedRepoPageDataNavCounts`.
+
+- [ ] Store versioned wrapper:
+
+```ts
+type RepoPageDataEnvelope<T> =
+  | { v: 2; syncedAt: string; data: T }
+  | T; // legacy: raw payload until migrated
+```
+
+- [ ] `getCachedRepoPageData<T>` unwraps v2 and legacy raw `T`.
+- [ ] `getCachedRepoPageDataEntry<T>` returns `{ data, syncedAt } | null`.
+- [ ] `setCachedRepoPageData` writes v2, with no hard TTL or a very long TTL; policy drives refresh.
+- [ ] `getRepoPageData`: if entry exists and `shouldRefresh(syncedAt, "repo-chrome")`, return data immediately and schedule one background `fetchAndCacheRepoPageData` per repo per throttle window.
+- [ ] Use a small per-repo refresh lock such as `repo-page-refresh-lock:{userId}:{owner}/{repo}` (`SET NX EX`) so repeated requests do not stampede GitHub.
+- [ ] Update `updateCachedRepoPageDataNavCounts` to unwrap v2 before merge and re-wrap v2 after updating.
+- [ ] Re-export entry helpers from `repo-data-cache-vc.ts`.
+
+**Validation:** stale page data returns without blocking; GitHub failure keeps stale UI.
+
+### Phase 5: Cache status introspection
+
+**Targets:** `github-sync-store.ts`, `repo-data-cache.ts`, `github-cache-status.ts`.
+
+- [ ] Export `getGithubCacheEntrySyncedAt(userId, cacheKey)` or use full entry where cheaper.
+- [ ] Repo page data status reads via `getCachedRepoPageDataEntry` from Phase 4; this is why status follows repo-page envelope work.
+- [ ] UI fragment status uses descriptors:
+  - if a cache has an envelope with `syncedAt`, show age/freshness,
+  - if a legacy owner-scoped cache only stores raw data, show `present` / `missing` until migrated.
+- [ ] `getRepoCacheStatus(userId, owner, repo)` must make no GitHub calls.
+- [ ] Include sync job counts and failed-row summaries.
+
+### Phase 6: Shared UI cache warm helpers
+
+**Targets:** new `repo-overview-cache-warmer.ts`, existing `overview-actions.ts`, `readme-actions.ts`, `revalidate-actions.ts`, `repo-data-cache.ts` as needed.
+
+- [ ] Extract shared helpers from Server Actions so the warmer can populate the exact caches the UI reads without importing app-route modules into `lib`.
+- [ ] `warmRepoFileTreeForLayout(owner, repo, defaultBranch, authCtx)`:
+  - calls `getRepoTree(owner, repo, defaultBranch, true, { authCtx })`,
+  - builds `FileTreeNode[]`,
+  - writes `setCachedRepoTree(owner, repo, tree)`,
+  - records the user-scoped `gh:{userId}:repo_tree:*` key via `getRepoTree`.
+- [ ] `getRepoReadmeHtmlCacheFirst(owner, repo, defaultBranch, authCtx, options?)` shared helper:
+  - reads `getCachedReadmeHtml(owner, repo)` before any GitHub call,
+  - on cache hit, returns cached HTML immediately and schedules/throttles a background refresh,
+  - on true miss, fetches README content, renders HTML with the existing markdown renderer, writes `setCachedReadmeHtml(owner, repo, html)`, and returns it,
+  - supports an explicit `forceRefresh` path for manual refresh Server Actions,
+  - optionally also populates `getRepoReadme` raw response cache without a duplicate GitHub call.
+- [ ] `page.tsx` must use the cache-first README helper (or `revalidateReadme` must become that cache-first wrapper and move force refresh to a separate helper) so warmed `readme_html:{owner}/{repo}` is actually used on first navigation.
+- [ ] `warmOverviewPRs` and `warmOverviewIssues`:
+  - reuse `getRepoPullRequests` / `getRepoIssues`,
+  - transform exactly like current overview actions,
+  - write `overview_prs` / `overview_issues`.
+- [ ] Add real cached `getRepoEvents(owner, repo, perPage, { authCtx })` in `github.ts`:
+  - descriptor/cache type `repo_events`,
+  - `readLocalFirstGitData`,
+  - `processGitDataSyncJob` support,
+  - not shareable.
+- [ ] `warmOverviewEvents` uses the cached `getRepoEvents` wrapper and writes `overview_events`.
+- [ ] `warmOverviewCIStatus` uses `fetchCheckStatusForRef` and writes `overview_ci`.
+- [ ] Layout metadata warm helpers are explicit, not optional:
+  - quick mode writes owner-scoped `repo_languages` from repo page data (`setCachedRepoLanguages`) and warms `repo_branches` / `repo_tags` for `CodeContentWrapper`,
+  - quick mode warms contributor avatars (`repo_contributor_avatars`) with the existing sidebar-sized limit when the repo is not empty; stage failures are non-fatal,
+  - full mode refreshes the same owner-scoped layout caches plus the user-scoped `gh:{userId}:repo_branches:*`, `repo_tags:*`, and `repo_contributors:*` response caches.
+- [ ] `warmOverviewCommitActivity` writes `overview_commit_activity`; do not call raw `getCommitActivity` unless the result is persisted.
+- [ ] Existing Server Actions in `overview-actions.ts`, `readme-actions.ts`, and `revalidate-actions.ts` delegate to the shared helpers to avoid divergent behavior.
+
+### Phase 7: Personal repo discovery and staged warming
+
+**Target:** `github-cache-warmer.ts`.
+
+- [ ] `discoverPersonalRepos(authCtx)` via `getUserRepos("updated", 100, { authCtx })`, `getUserOrgs(50, { authCtx })`, `getOrgRepos(org, ..., { authCtx })`.
+- [ ] Define `WarmableRepo` with owner, repo/name, full name, private flag, pushed/updated timestamps, default branch if known.
+- [ ] Dedupe by lowercase `owner/repo`.
+- [ ] Sort by `pushedAt` then `updatedAt`, newest first.
+- [ ] Respect `maxRepos`.
+
+**Quick mode stage order per repo:**
+
+1. `fetchAndCacheRepoPageData(owner, repo, { authCtx })` first; this provides default branch, latest commit, permissions, nav counts, languages.
+2. If repo is not empty, `warmRepoFileTreeForLayout(owner, repo, defaultBranch, authCtx)` using **default branch name** to match layout.
+3. `warmLayoutMetadataQuick(owner, repo, pageData, authCtx)`: owner-scoped languages from page data, owner-scoped branches/tags, and sidebar contributor avatars for layout/sidebar first paint.
+4. If repo is not empty, `getRepoReadmeHtmlCacheFirst(owner, repo, defaultBranch, authCtx)` so warmed `readme_html` is used by `page.tsx`.
+5. `warmOverviewPRs`, `warmOverviewIssues`, `warmOverviewEvents`, `warmOverviewCIStatus`.
+6. `getRepoWorkflowRuns(owner, repo, 50, { authCtx })` for Actions page cache.
+
+**Full mode adds:** releases, discussions (when enabled), `warmOverviewCommitActivity`, and full refresh of user-scoped branch/tag/contributor response caches in addition to the owner-scoped layout caches already warmed in quick mode.
+
+**Commit activity:** full mode may call `warmOverviewCommitActivity` because it persists `overview_commit_activity`. If a user-scoped stats cache is desired, add a `repo_commit_activity` `readLocalFirstGitData` wrapper before relying on it for status.
+
+**Limits:** `DEFAULT_MAX_REPOS = 100`, `DEFAULT_CONCURRENT_REPOS = 3`, `DEFAULT_CONCURRENT_STAGES_PER_REPO = 2`.
+
+Per-stage errors are aggregated; repo warming continues unless auth is lost or the run lock is lost.
+
+### Phase 8: Locks, warm API, and Inngest
+
+**Files:** `api/github-cache/warm/route.ts`, `github-cache-warmer.ts`, `github-cache-lock.ts` if split, new Inngest function registered in `app/api/inngest/route.ts`.
+
+- [ ] API route validates session and zod body (`mode`, `maxRepos`, `refreshStaleOnly`).
+- [ ] API route generates `runId = crypto.randomUUID()` and acquires `github-cache-warm-lock:{userId}` with that value.
+- [ ] If lock exists, route returns `{ accepted: false, skippedReason: "already-running" }`.
+- [ ] Inline dev path:
+  - resolve request auth,
+  - call warmer with `{ runId, lockAlreadyHeld: true }`,
+  - release lock in `finally` using compare-and-delete.
+- [ ] Production path:
+  - only enabled when `GITHUB_CACHE_WARM_PROD_ENABLED=1`,
+  - send Inngest event `github/cache.warm` with `{ userId, runId, lockKey, options }`,
+  - return `{ accepted: true, runId }` immediately,
+  - worker verifies lock value equals `runId`, resolves background auth, renews lock as needed, calls warmer, stores result, releases lock by matching `runId`.
+- [ ] If production warm is disabled, route releases the lock and returns `{ accepted: false, skippedReason: "disabled" }`.
+- [ ] Response never includes PAT; do not log body.
+- [ ] Store last `GithubCacheWarmResult` in Redis `github-cache-warm-last:{userId}` for debug UI with a reasonable TTL; no tokens or response payloads.
+
+### Phase 9: Browser-session warmer (gated)
+
+**Target:** `github-cache-warmer.tsx` in `(app)/layout.tsx`.
+
+- [ ] Render only if `NEXT_PUBLIC_GITHUB_CACHE_WARM_ENABLED === "1"`.
+- [ ] Use localStorage key `better-hub:github-cache:last-warm` with a throttle window.
+- [ ] Use BroadcastChannel when available so multiple tabs do not all POST.
+- [ ] POST warm API with quick mode and safe defaults.
+- [ ] Quiet retry on network failures only.
+- [ ] No spinner. If UI is added later, use skeleton-compatible background/status affordances.
+
+### Phase 10: Debug / cache status UI
+
+**Route:** `apps/web/src/app/(app)/debug/github-cache/page.tsx` (auth required).
+
+- [ ] Show user id/login, lock status, last warm result, sync job counts, failed jobs, and per-repo status from Phase 5.
+- [ ] Manual quick/full warm buttons call the same API route.
+- [ ] Show which cache targets are present/fresh/stale/missing using descriptors.
+- [ ] Never show tokens or raw cached payloads.
+
+### Phase 11: Docs, env example, and AGENTS.md
+
+- [ ] Add short section to repo `AGENTS.md`: env flags, warm modes, debug route, Redis key patterns, lock semantics, background auth resolver, “do not expand shareable cache without security review”.
+- [ ] Update `apps/web/.env.example` with cache flags and safe defaults:
+  - `NEXT_PUBLIC_GITHUB_CACHE_WARM_ENABLED=0`
+  - `GITHUB_CACHE_WARM_INLINE=1` (local/dev only; comment accordingly)
+  - `GITHUB_CACHE_WARM_PROD_ENABLED=0`
+  - `GITHUB_CACHE_SHARED_READ=1`
+  - optionally commented tuning vars: `GITHUB_CACHE_WARM_MAX_REPOS`, `GITHUB_CACHE_WARM_CONCURRENCY`, `GITHUB_CACHE_WARM_LOCK_TTL_SECONDS`
+- [ ] Document the one-time unsafe `ghpub:*` cleanup command/utility and validation scans.
+- [ ] Document that expanding shared-cache allowlist requires security review.
+
+### Phase 12 (optional): Durable Postgres cache
+
+- [ ] Write-through `GithubCacheEntry` for selected types; size limits; hydrate on Redis miss.
+- [ ] No new migration (table exists).
+
+## Proposed Implementation Order
+
+| Order | Phase | Milestone |
+| ---: | --- | --- |
+| 1 | **0** Shared cache fix + polluted-key cleanup | Security — deployable alone |
+| 2 | 1 Cache descriptors + policy | Foundation; removes key-builder drift |
+| 3 | 2 Sync-job dedupe repair | Prevent failed rows from blocking refreshes |
+| 4 | 3 Background auth context | Enables Inngest/worker warm |
+| 5 | 4 Repo page SWR | Faster repo chrome and status entry data |
+| 6 | 5 Status introspection | Debug prep |
+| 7 | 6 Shared UI cache warm helpers | Warms what UI actually reads |
+| 8 | 7 Warmer discovery + stages | Core warmer |
+| 9 | 8 API + Inngest + locks | Safe prod trigger |
+| 10 | 9 Client (gated) | Auto warm in dev / later prod |
+| 11 | 10 Debug UI | Observability |
+| 12 | 11 Docs/env/AGENTS | Handoff |
+| 13 | 12 Postgres | Optional |
+
+**First useful milestone (local):** Phases 0, 1, 2, 3, 4, 5, 6, 7, 8 (inline), 9 (env on), 10.
+
+**First production-safe milestone:** Phase 0 plus Phases 1–8 with background auth and Inngest verified. Keep client trigger off in production until then.
+
+## Testing Strategy
+
+### Unit
+
+- [ ] Policy freshness; shareable allowlist regression; former bad types are not shareable.
+- [ ] Descriptor key builders produce the exact keys existing producers/consumers use.
+- [ ] Unsafe shared-cache cleanup matches `ghpub:repo_*`, `ghpub:issue*`, `ghpub:pull_request*`, exact org-scoped patterns, without deleting `ghpub:user_public_orgs:*`.
+- [ ] Repo page envelope unwrap (legacy + v2).
+- [ ] `updateCachedRepoPageDataNavCounts` unwraps and re-wraps v2 data.
+- [ ] Sync-job enqueue revives failed rows and updates pending rows.
+- [ ] Background auth resolver decrypts mocked encrypted account token and does not log it.
+- [ ] Discovery dedupe/sort; warm error aggregation.
+- [ ] Lock acquire/verify/renew/release; release only deletes when stored value matches `runId`.
+- [ ] Cached `getRepoEvents` wrapper uses `readLocalFirstGitData` and enqueues `repo_events` jobs.
+
+### Integration
+
+- [ ] Warm API 401 without session; 400 bad body.
+- [ ] Lock: second concurrent request returns `already-running`.
+- [ ] Inline dev warm releases lock on success and failure.
+- [ ] Inngest handler verifies lock, resolves auth by `userId`, releases lock on success/failure, and records `auth-unavailable` without leaking tokens.
+- [ ] Warmed repo navigation hits `repo_page_data`, `repo_file_tree`, `readme_html`, owner-scoped layout metadata (`repo_languages`, `repo_branches`, `repo_tags`, `repo_contributor_avatars`), `overview_*`, and `repo_workflow_runs` caches without blocking on GitHub.
+- [ ] Existing Server Actions still produce the same data after delegating to shared helpers.
+
+### Manual (local)
+
+```bash
+docker compose up -d
+cd apps/web && bunx prisma generate && cd ../..
+# .env.local: UPSTASH_*, NEXT_PUBLIC_GITHUB_CACHE_WARM_ENABLED=1, GITHUB_CACHE_WARM_INLINE=1
+bun dev
+```
+
+- [ ] Sign in; trigger quick warm from debug page.
+- [ ] `docker exec -it better-hub-redis redis-cli --scan --pattern 'gh:*' | head`
+- [ ] `docker exec -it better-hub-redis redis-cli --scan --pattern 'repo_page_data:*' | head`
+- [ ] `docker exec -it better-hub-redis redis-cli --scan --pattern 'overview_*' | head`
+- [ ] Confirm no new unsafe keys after browsing private repos:
+  - `ghpub:repo_*`
+  - `ghpub:issue*`
+  - `ghpub:pull_request*`
+  - `ghpub:org:*`, `ghpub:org_repos:*`, `ghpub:org_members:*`
+- [ ] Stale repo page renders with GitHub blocked.
+- [ ] Debug page shows freshness/presence and warm errors; no tokens exposed.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Shared cache leak (current) | Cross-user private data | **Phase 0 first**, allowlist, polluted-key cleanup |
+| Warmer populates wrong cache | First navigation still blocks | Phase 6 warms `repo_file_tree`, cache-first `readme_html`, `overview_*`, owner-scoped layout metadata, and user-scoped GitHub response caches |
+| Long warm in HTTP handler | Timeouts, stuck lock | Inngest + compare-release; inline dev only |
+| Token unavailable in Inngest worker | Prod warm blocked | Background auth resolver; prod warm env gate; record `auth-unavailable` |
+| API and worker both acquire lock | Worker skips own run | API is sole acquirer for API-triggered runs; worker verifies passed `runId` only |
+| Lock expires before worker starts | Duplicate run possible | TTL sized for queue latency; worker exits `lock-lost` if value missing/different; consider renewal once started |
+| Failed Prisma sync job blocks refresh | Stale data forever for dedupe key | Phase 2 failed-row revival |
+| Legacy `repo_page_data` shape | Parse errors | Envelope v2 + raw fallback |
+| `getRepoEvents` uncached | Warm activity does not persist | Add real cached `repo_events` wrapper and overview cache writer |
+| `getCommitActivity` uncached | Wasted API in full mode | Only call via helper that writes `overview_commit_activity`, or add user-scoped wrapper later |
+| Multi-tab / multi-layer coordination | Rate limits | Document precedence; atomic user lock; client throttle/BroadcastChannel |
+| Redis restart | Cold cache | Accept V1; Phase 12 optional |
+| Phase 3 / Phase 0 behavior change | Rollback needed | Optional flags; Phase 0 is strictly safer |
+
+## Success Criteria
+
+- [ ] Phase 0 deployed: no repo-scoped/viewer-scoped data in `ghpub:*`.
+- [ ] Existing unsafe `ghpub:*` keys are purged or verified expired.
+- [ ] After sign-in (dev, flag on), warm runs once per throttle window.
+- [ ] Warmed repos: layout/overview use `repo_page_data`, `repo_file_tree`, cache-first `readme_html`, owner-scoped layout metadata (`repo_languages`, `repo_branches`, `repo_tags`, `repo_contributor_avatars`), `overview_*`, and `repo_workflow_runs` caches without blocking on GitHub.
+- [ ] Background refresh without loading spinners on hot paths.
+- [ ] GitHub outage: stale repo page still renders.
+- [ ] Debug page shows freshness, presence, job backlog, last warm result, and errors; no tokens exposed.
+- [ ] Inngest worker can warm from `{ userId, runId }` using background auth, or production warm remains disabled by env until it can.
+- [ ] Failed `GithubSyncJob` rows do not permanently block future refreshes.
+- [ ] `bun lint`, `bun fmt:check`, `bun typecheck`, `bun test` pass.
+
+## Environment Variables
+
+| Variable | Purpose |
+| --- | --- |
+| `NEXT_PUBLIC_GITHUB_CACHE_WARM_ENABLED` | `1` enables client warmer; default `0` in `.env.example` |
+| `GITHUB_CACHE_WARM_INLINE` | `1` allows synchronous warm in API route for local/dev |
+| `GITHUB_CACHE_WARM_PROD_ENABLED` | `1` allows API to enqueue production Inngest warm; default `0` until verified |
+| `GITHUB_CACHE_SHARED_READ` | Optional `0` to disable shared-cache reads during rollback/emergency response |
+| `GITHUB_CACHE_WARM_MAX_REPOS` | Optional default max repo count override |
+| `GITHUB_CACHE_WARM_CONCURRENCY` | Optional default repo concurrency override |
+| `GITHUB_CACHE_WARM_LOCK_TTL_SECONDS` | Optional lock TTL override; default should cover expected Inngest latency + warm time |
+
+## Later Enhancements
+
+- [ ] CLI `apps/web/scripts/warm-github-cache.mts` using the same background auth resolver and lock helpers.
+- [ ] Webhooks for invalidation.
+- [ ] Cache size accounting and pruning.
+- [ ] UI badge for stale/fresh/offline.
+- [ ] Adaptive warming from `recent-views` / pinned repos.
+- [ ] Refactor layout to use user-scoped `gh:{userId}:repo_tree:*` directly, then retire owner-scoped `repo_file_tree` if safe.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -28,6 +28,9 @@ DATABASE_URL=your_prisma_database_url
 UPSTASH_REDIS_REST_URL=http://localhost:8079
 UPSTASH_REDIS_REST_TOKEN=local_token
 
+# Set to 0 to bypass cross-user public GitHub cache reads during rollback/emergency response.
+GITHUB_CACHE_SHARED_READ=1
+
 # ──────────────────────────────────────────────
 # AI — Ghost assistant (required for AI features)
 # ──────────────────────────────────────────────

--- a/apps/web/scripts/purge-unsafe-shared-github-cache.ts
+++ b/apps/web/scripts/purge-unsafe-shared-github-cache.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+
+import { redis } from "../src/lib/redis";
+
+const UNSAFE_SHARED_CACHE_PATTERNS = [
+	"ghpub:repo_*",
+	"ghpub:issue*",
+	"ghpub:pull_request*",
+	"ghpub:org:*",
+	"ghpub:org_repos:*",
+	"ghpub:org_members:*",
+	"ghpub:file_content:*",
+	"ghpub:repo_contents:*",
+];
+
+const dryRun = process.argv.includes("--dry-run");
+
+async function scanAndDelete(pattern: string): Promise<number> {
+	let cursor = 0;
+	let matched = 0;
+
+	do {
+		const result = await redis.scan(cursor, { match: pattern, count: 100 });
+		const keys = result[1];
+		cursor = Number(result[0]);
+		matched += keys.length;
+
+		if (!dryRun && keys.length > 0) {
+			await redis.del(...keys);
+		}
+	} while (cursor !== 0);
+
+	return matched;
+}
+
+let total = 0;
+
+for (const pattern of UNSAFE_SHARED_CACHE_PATTERNS) {
+	const count = await scanAndDelete(pattern);
+	total += count;
+	console.log(
+		`${dryRun ? "Would delete" : "Deleted"} ${count} shared GitHub cache keys matching ${pattern}`,
+	);
+}
+
+console.log(
+	`${dryRun ? "Would delete" : "Deleted"} ${total} unsafe shared GitHub cache keys total`,
+);

--- a/apps/web/src/lib/github-auth-context.test.ts
+++ b/apps/web/src/lib/github-auth-context.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { findFirst, getServerSession, getAuthenticated, symmetricDecrypt, OctokitMock } = vi.hoisted(
+	() => {
+		const getAuthenticated = vi.fn();
+		const OctokitMock = vi.fn(function (
+			this: {
+				auth: string;
+				users: { getAuthenticated: typeof getAuthenticated };
+			},
+			options: { auth: string },
+		) {
+			this.auth = options.auth;
+			this.users = { getAuthenticated };
+		});
+		return {
+			findFirst: vi.fn(),
+			getServerSession: vi.fn(),
+			getAuthenticated,
+			symmetricDecrypt: vi.fn(),
+			OctokitMock,
+		};
+	},
+);
+
+vi.mock("./db", () => ({
+	prisma: {
+		account: { findFirst },
+	},
+}));
+
+vi.mock("./auth", () => ({
+	getServerSession,
+}));
+
+vi.mock("better-auth/crypto", () => ({
+	symmetricDecrypt,
+}));
+
+vi.mock("@octokit/rest", () => ({
+	Octokit: OctokitMock,
+}));
+
+vi.mock("next/headers", () => ({
+	headers: vi.fn(async () => new Headers()),
+}));
+
+describe("resolveGitHubAuthContextForUser", () => {
+	beforeEach(() => {
+		findFirst.mockReset();
+		getServerSession.mockReset();
+		getAuthenticated.mockReset();
+		symmetricDecrypt.mockReset();
+		OctokitMock.mockClear();
+		process.env.BETTER_AUTH_SECRET = "test-secret";
+	});
+
+	it("decrypts the stored GitHub account token and builds an auth context", async () => {
+		findFirst.mockResolvedValue({ accessToken: "encrypted-token" });
+		symmetricDecrypt.mockResolvedValue("plain-token");
+		getAuthenticated.mockResolvedValue({
+			data: {
+				login: "octo",
+				id: 123,
+				avatar_url: "https://example.com/avatar.png",
+			},
+		});
+
+		const { resolveGitHubAuthContextForUser } = await import("./github-auth-context");
+		const authCtx = await resolveGitHubAuthContextForUser("user-1");
+
+		expect(findFirst).toHaveBeenCalledWith({
+			where: {
+				userId: "user-1",
+				providerId: "github",
+				accessToken: { not: null },
+			},
+			orderBy: { updatedAt: "desc" },
+			select: { accessToken: true },
+		});
+		expect(symmetricDecrypt).toHaveBeenCalledWith({
+			key: "test-secret",
+			data: "encrypted-token",
+		});
+		expect(OctokitMock).toHaveBeenCalledWith({ auth: "plain-token" });
+		expect(authCtx).toMatchObject({
+			userId: "user-1",
+			token: "plain-token",
+			forceRefresh: false,
+			githubUser: { login: "octo", accessToken: "plain-token" },
+		});
+	});
+
+	it("returns null when no GitHub account token is available", async () => {
+		findFirst.mockResolvedValue(null);
+
+		const { resolveGitHubAuthContextForUser } = await import("./github-auth-context");
+		await expect(resolveGitHubAuthContextForUser("user-1")).resolves.toBeNull();
+		expect(symmetricDecrypt).not.toHaveBeenCalled();
+	});
+
+	it("returns a usable context if profile lookup fails", async () => {
+		findFirst.mockResolvedValue({ accessToken: "encrypted-token" });
+		symmetricDecrypt.mockResolvedValue("plain-token");
+		getAuthenticated.mockRejectedValue(new Error("rate limited"));
+
+		const { resolveGitHubAuthContextForUser } = await import("./github-auth-context");
+		const authCtx = await resolveGitHubAuthContextForUser("user-1");
+
+		expect(authCtx).toMatchObject({
+			userId: "user-1",
+			token: "plain-token",
+			githubUser: { accessToken: "plain-token" },
+		});
+	});
+});

--- a/apps/web/src/lib/github-auth-context.ts
+++ b/apps/web/src/lib/github-auth-context.ts
@@ -1,0 +1,91 @@
+import { Octokit } from "@octokit/rest";
+import { symmetricDecrypt } from "better-auth/crypto";
+import { headers } from "next/headers";
+import { cache } from "react";
+import { getServerSession } from "./auth";
+import type { $Session } from "./auth";
+import { prisma } from "./db";
+
+export interface GitHubAuthContext {
+	userId: string;
+	token: string;
+	octokit: Octokit;
+	forceRefresh: boolean;
+	githubUser: $Session["githubUser"];
+}
+
+function getForceRefreshFromHeaders(reqHeaders: Headers): boolean {
+	const cacheControl = reqHeaders.get("cache-control") ?? "";
+	const pragma = reqHeaders.get("pragma") ?? "";
+	return (
+		cacheControl.includes("no-cache") ||
+		cacheControl.includes("max-age=0") ||
+		pragma.includes("no-cache")
+	);
+}
+
+export const getRequestGitHubAuthContext = cache(async (): Promise<GitHubAuthContext | null> => {
+	const session = await getServerSession();
+	const reqHeaders = await headers();
+	if (!session) return null;
+	const token = session.githubUser.accessToken;
+
+	return {
+		userId: session.user.id,
+		token,
+		octokit: new Octokit({ auth: token }),
+		forceRefresh: getForceRefreshFromHeaders(reqHeaders),
+		githubUser: session.githubUser,
+	};
+});
+
+async function decryptStoredGitHubToken(encryptedToken: string): Promise<string | null> {
+	const secret = process.env.BETTER_AUTH_SECRET;
+	if (!secret) return null;
+	try {
+		return await symmetricDecrypt({ key: secret, data: encryptedToken });
+	} catch {
+		return null;
+	}
+}
+
+export async function resolveGitHubAuthContextForUser(
+	userId: string,
+): Promise<GitHubAuthContext | null> {
+	const account = await prisma.account.findFirst({
+		where: {
+			userId,
+			providerId: "github",
+			accessToken: { not: null },
+		},
+		orderBy: { updatedAt: "desc" },
+		select: { accessToken: true },
+	});
+
+	if (!account?.accessToken) return null;
+
+	const token = await decryptStoredGitHubToken(account.accessToken);
+	if (!token) return null;
+
+	const octokit = new Octokit({ auth: token });
+	let githubUser: GitHubAuthContext["githubUser"] = {
+		accessToken: token,
+	} as GitHubAuthContext["githubUser"];
+	try {
+		const response = await octokit.users.getAuthenticated();
+		githubUser = {
+			...response.data,
+			accessToken: token,
+		} as GitHubAuthContext["githubUser"];
+	} catch {
+		// Profile lookup is useful for parity with request auth, but warming can proceed without it.
+	}
+
+	return {
+		userId,
+		token,
+		octokit,
+		forceRefresh: false,
+		githubUser,
+	};
+}

--- a/apps/web/src/lib/github-cache-descriptors.test.ts
+++ b/apps/web/src/lib/github-cache-descriptors.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+	GITHUB_CACHE_DESCRIPTORS,
+	getGithubCacheDescriptor,
+	githubCacheKeys,
+} from "./github-cache-descriptors";
+
+describe("github cache descriptors", () => {
+	it("contains descriptors for V1 GitHub response, UI fragment, and public cache families", () => {
+		const expectedTypes = [
+			"user_repos",
+			"user_orgs",
+			"org_repos",
+			"repo",
+			"repo_tree",
+			"repo_readme",
+			"repo_issues",
+			"repo_pull_requests",
+			"repo_events",
+			"repo_workflow_runs",
+			"repo_branches",
+			"repo_tags",
+			"repo_releases",
+			"repo_contributors",
+			"repo_discussions",
+			"repo_nav_counts",
+			"repo_languages",
+			"repo_page_data",
+			"repo_file_tree",
+			"readme_html",
+			"overview_prs",
+			"overview_issues",
+			"overview_events",
+			"overview_commit_activity",
+			"overview_ci",
+			"user_profile",
+			"user_public_orgs",
+			"user_events",
+			"trending_repos",
+		];
+
+		for (const cacheType of expectedTypes) {
+			expect(getGithubCacheDescriptor(cacheType), cacheType).toBeDefined();
+		}
+		expect(GITHUB_CACHE_DESCRIPTORS.user_public_orgs.shareable).toBe(true);
+		expect(GITHUB_CACHE_DESCRIPTORS.repo_issues.shareable).toBe(false);
+	});
+
+	it("builds stable GitHub response cache keys", () => {
+		expect(githubCacheKeys.userRepos("updated", 30)).toBe("user_repos:updated:30");
+		expect(githubCacheKeys.repo("Owner", "Repo")).toBe("repo:owner/repo");
+		expect(
+			githubCacheKeys.repoContents("Owner", "Repo", "/src/app.ts/", " main "),
+		).toBe("repo_contents:owner/repo:main:src%2Fapp.ts");
+		expect(githubCacheKeys.repoContents("Owner", "Repo", "", undefined)).toBe(
+			"repo_contents:owner/repo:~:~",
+		);
+		expect(githubCacheKeys.repoTree("Owner", "Repo", "abc123", true)).toBe(
+			"repo_tree:owner/repo:abc123:1",
+		);
+		expect(githubCacheKeys.repoReadme("Owner", "Repo", "")).toBe(
+			"repo_readme:owner/repo:~",
+		);
+		expect(githubCacheKeys.orgRepos("Org", "pushed", "private", 100)).toBe(
+			"org_repos:org:pushed:private:100",
+		);
+		expect(githubCacheKeys.searchIssues("is:pr is:open repo:Owner/Repo", 20)).toBe(
+			"search_issues:is%3Apr%20is%3Aopen%20repo%3AOwner%2FRepo:20",
+		);
+		expect(githubCacheKeys.trendingRepos("weekly", 10)).toBe(
+			"trending_repos:weekly:10:~",
+		);
+		expect(githubCacheKeys.repoDiscussions("Owner", "Repo")).toBe(
+			"repo_discussions:v2:owner/repo",
+		);
+	});
+
+	it("builds stable UI fragment cache keys", () => {
+		expect(githubCacheKeys.repoPageData("user-1", "Owner", "Repo")).toBe(
+			"repo_page_data:user-1:owner/repo",
+		);
+		expect(githubCacheKeys.repoFileTree("Owner", "Repo")).toBe(
+			"repo_file_tree:owner/repo",
+		);
+		expect(githubCacheKeys.readmeHtml("Owner", "Repo")).toBe("readme_html:owner/repo");
+		expect(githubCacheKeys.overviewPRs("Owner", "Repo")).toBe(
+			"overview_prs:owner/repo",
+		);
+		expect(githubCacheKeys.overviewIssues("Owner", "Repo")).toBe(
+			"overview_issues:owner/repo",
+		);
+		expect(githubCacheKeys.overviewEvents("Owner", "Repo")).toBe(
+			"overview_events:owner/repo",
+		);
+		expect(githubCacheKeys.overviewCommitActivity("Owner", "Repo")).toBe(
+			"overview_commit_activity:owner/repo",
+		);
+		expect(githubCacheKeys.overviewCI("Owner", "Repo")).toBe("overview_ci:owner/repo");
+	});
+});

--- a/apps/web/src/lib/github-cache-descriptors.ts
+++ b/apps/web/src/lib/github-cache-descriptors.ts
@@ -1,0 +1,472 @@
+export type GithubCacheDataClass =
+	| "repo-chrome"
+	| "repo-inventory"
+	| "hot-list"
+	| "ci"
+	| "activity"
+	| "code-tree"
+	| "readme"
+	| "stats"
+	| "identity";
+
+export type GithubCacheScope = "user" | "owner-repo" | "org" | "shared-public" | "viewer";
+
+export interface GithubCacheDescriptor {
+	cacheType: string;
+	dataClass: GithubCacheDataClass;
+	scope: GithubCacheScope;
+	shareable: boolean;
+}
+
+export const GITHUB_CACHE_DESCRIPTORS = {
+	user_repos: {
+		cacheType: "user_repos",
+		dataClass: "repo-inventory",
+		scope: "user",
+		shareable: false,
+	},
+	user_orgs: {
+		cacheType: "user_orgs",
+		dataClass: "repo-inventory",
+		scope: "user",
+		shareable: false,
+	},
+	org_repos: {
+		cacheType: "org_repos",
+		dataClass: "repo-inventory",
+		scope: "org",
+		shareable: false,
+	},
+	repo: {
+		cacheType: "repo",
+		dataClass: "repo-chrome",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_tree: {
+		cacheType: "repo_tree",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_readme: {
+		cacheType: "repo_readme",
+		dataClass: "readme",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_issues: {
+		cacheType: "repo_issues",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_pull_requests: {
+		cacheType: "repo_pull_requests",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_events: {
+		cacheType: "repo_events",
+		dataClass: "activity",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_workflow_runs: {
+		cacheType: "repo_workflow_runs",
+		dataClass: "ci",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_branches: {
+		cacheType: "repo_branches",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_tags: {
+		cacheType: "repo_tags",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_releases: {
+		cacheType: "repo_releases",
+		dataClass: "repo-chrome",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_contributors: {
+		cacheType: "repo_contributors",
+		dataClass: "stats",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_discussions: {
+		cacheType: "repo_discussions",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_nav_counts: {
+		cacheType: "repo_nav_counts",
+		dataClass: "repo-chrome",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_languages: {
+		cacheType: "repo_languages",
+		dataClass: "stats",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_workflows: {
+		cacheType: "repo_workflows",
+		dataClass: "ci",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_contents: {
+		cacheType: "repo_contents",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	file_content: {
+		cacheType: "file_content",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	user_profile: {
+		cacheType: "user_profile",
+		dataClass: "identity",
+		scope: "shared-public",
+		shareable: true,
+	},
+	user_public_orgs: {
+		cacheType: "user_public_orgs",
+		dataClass: "identity",
+		scope: "shared-public",
+		shareable: true,
+	},
+	user_events: {
+		cacheType: "user_events",
+		dataClass: "activity",
+		scope: "shared-public",
+		shareable: true,
+	},
+	trending_repos: {
+		cacheType: "trending_repos",
+		dataClass: "repo-inventory",
+		scope: "shared-public",
+		shareable: true,
+	},
+	user_public_repos: {
+		cacheType: "user_public_repos",
+		dataClass: "repo-inventory",
+		scope: "viewer",
+		shareable: false,
+	},
+	authenticated_user: {
+		cacheType: "authenticated_user",
+		dataClass: "identity",
+		scope: "viewer",
+		shareable: false,
+	},
+	org: {
+		cacheType: "org",
+		dataClass: "identity",
+		scope: "org",
+		shareable: false,
+	},
+	org_members: {
+		cacheType: "org_members",
+		dataClass: "identity",
+		scope: "org",
+		shareable: false,
+	},
+	notifications: {
+		cacheType: "notifications",
+		dataClass: "activity",
+		scope: "viewer",
+		shareable: false,
+	},
+	search_issues: {
+		cacheType: "search_issues",
+		dataClass: "hot-list",
+		scope: "viewer",
+		shareable: false,
+	},
+	starred_repos: {
+		cacheType: "starred_repos",
+		dataClass: "repo-inventory",
+		scope: "viewer",
+		shareable: false,
+	},
+	contributions: {
+		cacheType: "contributions",
+		dataClass: "activity",
+		scope: "viewer",
+		shareable: false,
+	},
+	person_repo_activity: {
+		cacheType: "person_repo_activity",
+		dataClass: "activity",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	pr_bundle: {
+		cacheType: "pr_bundle",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	repo_page_data: {
+		cacheType: "repo_page_data",
+		dataClass: "repo-chrome",
+		scope: "user",
+		shareable: false,
+	},
+	repo_file_tree: {
+		cacheType: "repo_file_tree",
+		dataClass: "code-tree",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	readme_html: {
+		cacheType: "readme_html",
+		dataClass: "readme",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	overview_prs: {
+		cacheType: "overview_prs",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	overview_issues: {
+		cacheType: "overview_issues",
+		dataClass: "hot-list",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	overview_events: {
+		cacheType: "overview_events",
+		dataClass: "activity",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	overview_commit_activity: {
+		cacheType: "overview_commit_activity",
+		dataClass: "stats",
+		scope: "owner-repo",
+		shareable: false,
+	},
+	overview_ci: {
+		cacheType: "overview_ci",
+		dataClass: "ci",
+		scope: "owner-repo",
+		shareable: false,
+	},
+} as const satisfies Record<string, GithubCacheDescriptor>;
+
+export type GithubCacheType = keyof typeof GITHUB_CACHE_DESCRIPTORS;
+
+export function getGithubCacheDescriptor(cacheType: string): GithubCacheDescriptor | undefined {
+	return GITHUB_CACHE_DESCRIPTORS[cacheType as GithubCacheType];
+}
+
+export function normalizeGithubCacheRef(ref?: string): string {
+	const value = ref?.trim();
+	return value ? value : "";
+}
+
+export function normalizeGithubCachePath(path: string): string {
+	return path.replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+export function normalizeGithubRepoKey(owner: string, repo: string): string {
+	return `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+}
+
+export function githubCacheKeyPart(value: string): string {
+	return encodeURIComponent(value === "" ? "~" : value);
+}
+
+function repoKey(owner: string, repo: string, suffix: string): string {
+	return `${suffix}:${normalizeGithubRepoKey(owner, repo)}`;
+}
+
+function userRepoKey(userId: string, owner: string, repo: string, suffix: string): string {
+	return `${suffix}:${userId}:${normalizeGithubRepoKey(owner, repo)}`;
+}
+
+export const githubCacheKeys = {
+	userRepos(sort: string, perPage: number): string {
+		return `user_repos:${sort}:${perPage}`;
+	},
+	repo(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo");
+	},
+	repoContents(owner: string, repo: string, path: string, ref?: string): string {
+		return `repo_contents:${normalizeGithubRepoKey(owner, repo)}:${githubCacheKeyPart(
+			normalizeGithubCacheRef(ref),
+		)}:${githubCacheKeyPart(normalizeGithubCachePath(path))}`;
+	},
+	repoTree(owner: string, repo: string, treeSha: string, recursive: boolean): string {
+		return `repo_tree:${normalizeGithubRepoKey(owner, repo)}:${githubCacheKeyPart(
+			treeSha,
+		)}:${recursive ? "1" : "0"}`;
+	},
+	repoBranches(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_branches");
+	},
+	repoTags(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_tags");
+	},
+	repoReleases(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_releases");
+	},
+	fileContent(owner: string, repo: string, path: string, ref?: string): string {
+		return `file_content:${normalizeGithubRepoKey(owner, repo)}:${githubCacheKeyPart(
+			normalizeGithubCacheRef(ref),
+		)}:${githubCacheKeyPart(normalizeGithubCachePath(path))}`;
+	},
+	repoReadme(owner: string, repo: string, ref?: string): string {
+		return `repo_readme:${normalizeGithubRepoKey(owner, repo)}:${githubCacheKeyPart(
+			normalizeGithubCacheRef(ref),
+		)}`;
+	},
+	authenticatedUser(): string {
+		return "authenticated_user";
+	},
+	userOrgs(perPage: number): string {
+		return `user_orgs:${perPage}`;
+	},
+	org(org: string): string {
+		return `org:${org.toLowerCase()}`;
+	},
+	orgRepos(org: string, sort: string, type: string, perPage: number): string {
+		return `org_repos:${org.toLowerCase()}:${sort}:${type}:${perPage}`;
+	},
+	notifications(perPage: number): string {
+		return `notifications:${perPage}`;
+	},
+	searchIssues(query: string, perPage: number): string {
+		return `search_issues:${githubCacheKeyPart(query)}:${perPage}`;
+	},
+	userEvents(username: string, perPage: number): string {
+		return `user_events:${username.toLowerCase()}:${perPage}`;
+	},
+	starredRepos(perPage: number): string {
+		return `starred_repos:${perPage}`;
+	},
+	contributions(username: string): string {
+		return `contributions:v3:${username.toLowerCase()}`;
+	},
+	trendingRepos(since: string, perPage: number, language?: string): string {
+		return `trending_repos:${since}:${perPage}:${githubCacheKeyPart(language ?? "")}`;
+	},
+	repoIssues(owner: string, repo: string, state: string): string {
+		return `repo_issues:${normalizeGithubRepoKey(owner, repo)}:${state}`;
+	},
+	repoPullRequests(owner: string, repo: string, state: string): string {
+		return `repo_pull_requests:${normalizeGithubRepoKey(owner, repo)}:${state}`;
+	},
+	issue(owner: string, repo: string, issueNumber: number): string {
+		return `issue:${normalizeGithubRepoKey(owner, repo)}:${issueNumber}`;
+	},
+	issueComments(owner: string, repo: string, issueNumber: number): string {
+		return `issue_comments:${normalizeGithubRepoKey(owner, repo)}:${issueNumber}`;
+	},
+	pullRequest(owner: string, repo: string, pullNumber: number): string {
+		return `pull_request:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	pullRequestFiles(owner: string, repo: string, pullNumber: number): string {
+		return `pull_request_files:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	pullRequestComments(owner: string, repo: string, pullNumber: number): string {
+		return `pull_request_comments:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	pullRequestReviews(owner: string, repo: string, pullNumber: number): string {
+		return `pull_request_reviews:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	pullRequestCommits(owner: string, repo: string, pullNumber: number): string {
+		return `pull_request_commits:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	repoContributors(owner: string, repo: string, perPage: number): string {
+		return `repo_contributors:${normalizeGithubRepoKey(owner, repo)}:${perPage}`;
+	},
+	userProfile(username: string): string {
+		return `user_profile:${username.toLowerCase()}`;
+	},
+	userPublicRepos(username: string, perPage: number): string {
+		return `user_public_repos:${username.toLowerCase()}:${perPage}`;
+	},
+	userPublicOrgs(username: string): string {
+		return `user_public_orgs:${username.toLowerCase()}`;
+	},
+	repoWorkflows(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_workflows");
+	},
+	repoWorkflowRuns(owner: string, repo: string, perPage: number): string {
+		return `repo_workflow_runs:${normalizeGithubRepoKey(owner, repo)}:${perPage}`;
+	},
+	repoNavCounts(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_nav_counts");
+	},
+	repoLanguages(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_languages");
+	},
+	orgMembers(org: string, perPage: number): string {
+		return `org_members:${org.toLowerCase()}:${perPage}`;
+	},
+	personRepoActivity(owner: string, repo: string, username: string): string {
+		return `person_repo_activity:${normalizeGithubRepoKey(
+			owner,
+			repo,
+		)}:${username.toLowerCase()}`;
+	},
+	prBundle(owner: string, repo: string, pullNumber: number): string {
+		return `pr_bundle:${normalizeGithubRepoKey(owner, repo)}:${pullNumber}`;
+	},
+	repoDiscussions(owner: string, repo: string): string {
+		return `repo_discussions:v2:${normalizeGithubRepoKey(owner, repo)}`;
+	},
+	repoIssuesPage(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_issues_page");
+	},
+	repoEvents(owner: string, repo: string, perPage: number): string {
+		return `repo_events:${normalizeGithubRepoKey(owner, repo)}:${perPage}`;
+	},
+	defaultBranch(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_default_branch");
+	},
+	repoPageData(userId: string, owner: string, repo: string): string {
+		return userRepoKey(userId, owner, repo, "repo_page_data");
+	},
+	repoFileTree(owner: string, repo: string): string {
+		return repoKey(owner, repo, "repo_file_tree");
+	},
+	readmeHtml(owner: string, repo: string): string {
+		return repoKey(owner, repo, "readme_html");
+	},
+	overviewPRs(owner: string, repo: string): string {
+		return repoKey(owner, repo, "overview_prs");
+	},
+	overviewIssues(owner: string, repo: string): string {
+		return repoKey(owner, repo, "overview_issues");
+	},
+	overviewEvents(owner: string, repo: string): string {
+		return repoKey(owner, repo, "overview_events");
+	},
+	overviewCommitActivity(owner: string, repo: string): string {
+		return repoKey(owner, repo, "overview_commit_activity");
+	},
+	overviewCI(owner: string, repo: string): string {
+		return repoKey(owner, repo, "overview_ci");
+	},
+};

--- a/apps/web/src/lib/github-cache-policy.test.ts
+++ b/apps/web/src/lib/github-cache-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { isShareableCacheType, isUnsafeSharedCacheType } from "./github-cache-policy";
+
+describe("github cache shared policy", () => {
+	it("allows only public cache types to be shared", () => {
+		expect(isShareableCacheType("user_profile")).toBe(true);
+		expect(isShareableCacheType("user_public_orgs")).toBe(true);
+		expect(isShareableCacheType("user_events")).toBe(true);
+		expect(isShareableCacheType("trending_repos")).toBe(true);
+	});
+
+	it("does not deny public org metadata by substring", () => {
+		expect(isUnsafeSharedCacheType("user_public_orgs")).toBe(false);
+		expect(isShareableCacheType("user_public_orgs")).toBe(true);
+	});
+
+	it("rejects formerly shared repo, issue, pull-request, org, and viewer-scoped types", () => {
+		const unsafeTypes = [
+			"repo",
+			"repo_branches",
+			"repo_tags",
+			"repo_releases",
+			"repo_issues",
+			"repo_pull_requests",
+			"repo_contributors",
+			"repo_workflows",
+			"repo_workflow_runs",
+			"repo_nav_counts",
+			"repo_contents",
+			"repo_tree",
+			"repo_readme",
+			"repo_discussions",
+			"issue",
+			"issue_comments",
+			"pull_request",
+			"pull_request_files",
+			"pull_request_comments",
+			"pull_request_reviews",
+			"pull_request_commits",
+			"org",
+			"org_repos",
+			"org_members",
+			"file_content",
+			"notifications",
+			"search_issues",
+			"authenticated_user",
+			"starred_repos",
+			"contributions",
+			"person_repo_activity",
+			"pr_bundle",
+			"user_repos",
+			"user_orgs",
+			"user_public_repos",
+		];
+
+		for (const cacheType of unsafeTypes) {
+			expect(isShareableCacheType(cacheType), cacheType).toBe(false);
+		}
+	});
+
+	it("keeps the explicit unsafe guard in front of future allowlist mistakes", () => {
+		expect(isUnsafeSharedCacheType("repo_anything_new")).toBe(true);
+		expect(isUnsafeSharedCacheType("issue_activity")).toBe(true);
+		expect(isUnsafeSharedCacheType("pull_request_timeline")).toBe(true);
+	});
+});

--- a/apps/web/src/lib/github-cache-policy.test.ts
+++ b/apps/web/src/lib/github-cache-policy.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { isShareableCacheType, isUnsafeSharedCacheType } from "./github-cache-policy";
+import { describe, expect, it, vi } from "vitest";
+import {
+	getGithubCachePolicy,
+	isFresh,
+	isShareableCacheType,
+	isUnsafeSharedCacheType,
+	shouldRefresh,
+} from "./github-cache-policy";
 
 describe("github cache shared policy", () => {
 	it("allows only public cache types to be shared", () => {
@@ -62,5 +68,38 @@ describe("github cache shared policy", () => {
 		expect(isUnsafeSharedCacheType("repo_anything_new")).toBe(true);
 		expect(isUnsafeSharedCacheType("issue_activity")).toBe(true);
 		expect(isUnsafeSharedCacheType("pull_request_timeline")).toBe(true);
+	});
+
+	it("returns V1 freshness policy defaults", () => {
+		expect(getGithubCachePolicy("ci")).toEqual({
+			freshForMs: 30 * 1000,
+			refreshAfterMs: 60 * 1000,
+			expireAfterMs: null,
+		});
+		expect(getGithubCachePolicy("repo-inventory")).toEqual({
+			freshForMs: 5 * 60 * 1000,
+			refreshAfterMs: 15 * 60 * 1000,
+			expireAfterMs: null,
+		});
+		expect(getGithubCachePolicy("stats")).toEqual({
+			freshForMs: 6 * 60 * 60 * 1000,
+			refreshAfterMs: 24 * 60 * 60 * 1000,
+			expireAfterMs: null,
+		});
+	});
+
+	it("classifies fresh and refreshable entries by data class", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-23T18:00:00.000Z"));
+		try {
+			expect(isFresh("2026-06-23T17:59:40.000Z", "ci")).toBe(true);
+			expect(isFresh("2026-06-23T17:59:20.000Z", "ci")).toBe(false);
+			expect(shouldRefresh("2026-06-23T17:59:20.000Z", "ci")).toBe(false);
+			expect(shouldRefresh("2026-06-23T17:58:59.000Z", "ci")).toBe(true);
+			expect(isFresh(null, "ci")).toBe(false);
+			expect(shouldRefresh(null, "ci")).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/apps/web/src/lib/github-cache-policy.ts
+++ b/apps/web/src/lib/github-cache-policy.ts
@@ -1,9 +1,39 @@
-const SHAREABLE_CACHE_TYPES: ReadonlySet<string> = new Set([
-	"user_profile",
-	"user_public_orgs",
-	"user_events",
-	"trending_repos",
-]);
+import { getGithubCacheDescriptor, type GithubCacheDataClass } from "./github-cache-descriptors";
+
+export type { GithubCacheDataClass };
+
+export interface GithubCachePolicy {
+	freshForMs: number;
+	refreshAfterMs: number;
+	expireAfterMs: number | null;
+}
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+
+const GITHUB_CACHE_POLICIES = {
+	"hot-list": { freshForMs: MINUTE, refreshAfterMs: 2 * MINUTE, expireAfterMs: null },
+	ci: { freshForMs: 30 * 1000, refreshAfterMs: MINUTE, expireAfterMs: null },
+	activity: { freshForMs: 2 * MINUTE, refreshAfterMs: 5 * MINUTE, expireAfterMs: null },
+	"repo-chrome": {
+		freshForMs: 10 * MINUTE,
+		refreshAfterMs: 30 * MINUTE,
+		expireAfterMs: null,
+	},
+	"code-tree": {
+		freshForMs: 15 * MINUTE,
+		refreshAfterMs: HOUR,
+		expireAfterMs: null,
+	},
+	readme: { freshForMs: 15 * MINUTE, refreshAfterMs: HOUR, expireAfterMs: null },
+	stats: { freshForMs: 6 * HOUR, refreshAfterMs: 24 * HOUR, expireAfterMs: null },
+	"repo-inventory": {
+		freshForMs: 5 * MINUTE,
+		refreshAfterMs: 15 * MINUTE,
+		expireAfterMs: null,
+	},
+	identity: { freshForMs: 15 * MINUTE, refreshAfterMs: HOUR, expireAfterMs: null },
+} satisfies Record<GithubCacheDataClass, GithubCachePolicy>;
 
 const UNSAFE_EXACT_SHARED_CACHE_TYPES: ReadonlySet<string> = new Set([
 	"repo",
@@ -33,9 +63,32 @@ export function isUnsafeSharedCacheType(cacheType: string): boolean {
 /** Types safe for ghpub:* - allowlist only; no repo-scoped or viewer-specific data. */
 export function isShareableCacheType(cacheType: string): boolean {
 	if (isUnsafeSharedCacheType(cacheType)) return false;
-	return SHAREABLE_CACHE_TYPES.has(cacheType);
+	return getGithubCacheDescriptor(cacheType)?.shareable === true;
 }
 
 export function isSharedCacheReadEnabled(): boolean {
 	return process.env.GITHUB_CACHE_SHARED_READ !== "0";
+}
+
+export function getGithubCachePolicy(dataClass: GithubCacheDataClass): GithubCachePolicy {
+	return GITHUB_CACHE_POLICIES[dataClass];
+}
+
+function ageMs(syncedAt: string | null): number | null {
+	if (!syncedAt) return null;
+	const timestamp = Date.parse(syncedAt);
+	if (Number.isNaN(timestamp)) return null;
+	return Math.max(0, Date.now() - timestamp);
+}
+
+export function isFresh(syncedAt: string | null, dataClass: GithubCacheDataClass): boolean {
+	const age = ageMs(syncedAt);
+	if (age === null) return false;
+	return age < getGithubCachePolicy(dataClass).freshForMs;
+}
+
+export function shouldRefresh(syncedAt: string | null, dataClass: GithubCacheDataClass): boolean {
+	const age = ageMs(syncedAt);
+	if (age === null) return true;
+	return age >= getGithubCachePolicy(dataClass).refreshAfterMs;
 }

--- a/apps/web/src/lib/github-cache-policy.ts
+++ b/apps/web/src/lib/github-cache-policy.ts
@@ -1,0 +1,41 @@
+const SHAREABLE_CACHE_TYPES: ReadonlySet<string> = new Set([
+	"user_profile",
+	"user_public_orgs",
+	"user_events",
+	"trending_repos",
+]);
+
+const UNSAFE_EXACT_SHARED_CACHE_TYPES: ReadonlySet<string> = new Set([
+	"repo",
+	"org",
+	"org_repos",
+	"org_members",
+	"repo_contents",
+	"file_content",
+	"notifications",
+	"search_issues",
+	"authenticated_user",
+	"starred_repos",
+	"contributions",
+	"person_repo_activity",
+	"pr_bundle",
+]);
+
+export function isUnsafeSharedCacheType(cacheType: string): boolean {
+	return (
+		cacheType.startsWith("repo_") ||
+		cacheType.startsWith("issue") ||
+		cacheType.startsWith("pull_request") ||
+		UNSAFE_EXACT_SHARED_CACHE_TYPES.has(cacheType)
+	);
+}
+
+/** Types safe for ghpub:* - allowlist only; no repo-scoped or viewer-specific data. */
+export function isShareableCacheType(cacheType: string): boolean {
+	if (isUnsafeSharedCacheType(cacheType)) return false;
+	return SHAREABLE_CACHE_TYPES.has(cacheType);
+}
+
+export function isSharedCacheReadEnabled(): boolean {
+	return process.env.GITHUB_CACHE_SHARED_READ !== "0";
+}

--- a/apps/web/src/lib/github-sync-store.test.ts
+++ b/apps/web/src/lib/github-sync-store.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { githubSyncJob } = vi.hoisted(() => ({
+	githubSyncJob: {
+		findUnique: vi.fn(),
+		create: vi.fn(),
+		updateMany: vi.fn(),
+	},
+}));
+
+vi.mock("./db", () => ({
+	prisma: { githubSyncJob },
+}));
+
+vi.mock("./redis", () => ({
+	redis: {},
+}));
+
+describe("enqueueGithubSyncJob", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-06-23T18:00:00.000Z"));
+		githubSyncJob.findUnique.mockReset();
+		githubSyncJob.create.mockReset();
+		githubSyncJob.updateMany.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("creates a pending job when no dedupe row exists", async () => {
+		githubSyncJob.findUnique.mockResolvedValue(null);
+		githubSyncJob.create.mockResolvedValue({});
+
+		const { enqueueGithubSyncJob } = await import("./github-sync-store");
+		await enqueueGithubSyncJob("user-1", "repo:owner/repo", "repo", {
+			owner: "owner",
+		});
+
+		expect(githubSyncJob.create).toHaveBeenCalledWith({
+			data: {
+				userId: "user-1",
+				dedupeKey: "repo:owner/repo",
+				jobType: "repo",
+				payloadJson: JSON.stringify({ owner: "owner" }),
+				status: "pending",
+				attempts: 0,
+				nextAttemptAt: "2026-06-23T18:00:00.000Z",
+				createdAt: "2026-06-23T18:00:00.000Z",
+				updatedAt: "2026-06-23T18:00:00.000Z",
+			},
+		});
+	});
+
+	it("revives a failed row for a new refresh", async () => {
+		githubSyncJob.findUnique.mockResolvedValue({ id: 42, status: "failed" });
+		githubSyncJob.updateMany.mockResolvedValue({ count: 1 });
+
+		const { enqueueGithubSyncJob } = await import("./github-sync-store");
+		await enqueueGithubSyncJob("user-1", "repo:owner/repo", "repo", {
+			owner: "new-owner",
+		});
+
+		expect(githubSyncJob.updateMany).toHaveBeenCalledWith({
+			where: { id: 42, status: "failed" },
+			data: {
+				jobType: "repo",
+				payloadJson: JSON.stringify({ owner: "new-owner" }),
+				status: "pending",
+				attempts: 0,
+				nextAttemptAt: "2026-06-23T18:00:00.000Z",
+				startedAt: null,
+				lastError: null,
+				updatedAt: "2026-06-23T18:00:00.000Z",
+			},
+		});
+		expect(githubSyncJob.create).not.toHaveBeenCalled();
+	});
+
+	it("updates an existing pending row without delaying the refresh", async () => {
+		githubSyncJob.findUnique.mockResolvedValue({ id: 7, status: "pending" });
+		githubSyncJob.updateMany.mockResolvedValue({ count: 1 });
+
+		const { enqueueGithubSyncJob } = await import("./github-sync-store");
+		await enqueueGithubSyncJob("user-1", "repo:owner/repo", "repo", {
+			owner: "updated",
+		});
+
+		expect(githubSyncJob.updateMany).toHaveBeenCalledWith({
+			where: { id: 7, status: "pending" },
+			data: {
+				jobType: "repo",
+				payloadJson: JSON.stringify({ owner: "updated" }),
+				nextAttemptAt: "2026-06-23T18:00:00.000Z",
+				updatedAt: "2026-06-23T18:00:00.000Z",
+			},
+		});
+		expect(githubSyncJob.create).not.toHaveBeenCalled();
+	});
+
+	it("leaves an existing running row untouched", async () => {
+		githubSyncJob.findUnique.mockResolvedValue({ id: 9, status: "running" });
+
+		const { enqueueGithubSyncJob } = await import("./github-sync-store");
+		await enqueueGithubSyncJob("user-1", "repo:owner/repo", "repo", {
+			owner: "owner",
+		});
+
+		expect(githubSyncJob.updateMany).not.toHaveBeenCalled();
+		expect(githubSyncJob.create).not.toHaveBeenCalled();
+	});
+
+	it("ignores concurrent insert race errors", async () => {
+		githubSyncJob.findUnique.mockResolvedValue(null);
+		githubSyncJob.create.mockRejectedValue({ code: "P2002" });
+
+		const { enqueueGithubSyncJob } = await import("./github-sync-store");
+		await expect(
+			enqueueGithubSyncJob("user-1", "repo:owner/repo", "repo", {
+				owner: "owner",
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/github-sync-store.ts
+++ b/apps/web/src/lib/github-sync-store.ts
@@ -122,34 +122,75 @@ export async function enqueueGithubSyncJob<TPayload>(
 	payload: TPayload,
 ) {
 	const now = new Date().toISOString();
+	const payloadJson = JSON.stringify(payload);
+	const existing = await prisma.githubSyncJob.findUnique({
+		where: { userId_dedupeKey: { userId, dedupeKey } },
+		select: { id: true, status: true },
+	});
+
+	if (existing?.status === "running") return;
+
+	if (existing?.status === "failed") {
+		await prisma.githubSyncJob.updateMany({
+			where: { id: existing.id, status: "failed" },
+			data: {
+				jobType,
+				payloadJson,
+				status: "pending",
+				attempts: 0,
+				nextAttemptAt: now,
+				startedAt: null,
+				lastError: null,
+				updatedAt: now,
+			},
+		});
+		return;
+	}
+
+	if (existing?.status === "pending") {
+		await prisma.githubSyncJob.updateMany({
+			where: { id: existing.id, status: "pending" },
+			data: {
+				jobType,
+				payloadJson,
+				nextAttemptAt: now,
+				updatedAt: now,
+			},
+		});
+		return;
+	}
 
 	try {
-		await prisma.githubSyncJob.upsert({
-			where: { userId_dedupeKey: { userId, dedupeKey } },
-			create: {
+		await prisma.githubSyncJob.create({
+			data: {
 				userId,
 				dedupeKey,
 				jobType,
-				payloadJson: JSON.stringify(payload),
+				payloadJson,
 				status: "pending",
 				attempts: 0,
 				nextAttemptAt: now,
 				createdAt: now,
 				updatedAt: now,
 			},
-			update: {},
 		});
 	} catch (e) {
-		if (
-			e instanceof Prisma.PrismaClientKnownRequestError &&
-			(e.code === "P2002" || e.code === "P2025")
-		) {
+		if (isKnownPrismaRequestError(e) && (e.code === "P2002" || e.code === "P2025")) {
 			// P2002: unique constraint violation (concurrent insert race)
-			// P2025: record not found during upsert (concurrent insert + delete race)
+			// P2025: record not found during create/delete race
 			return;
 		}
 		throw e;
 	}
+}
+
+function isKnownPrismaRequestError(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+	if (error instanceof Prisma.PrismaClientKnownRequestError) return true;
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		typeof (error as { code?: unknown }).code === "string"
+	);
 }
 
 async function recoverTimedOutRunningJobs(userId: string) {

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -19,6 +19,11 @@ import {
 import { redis } from "./redis";
 import { computeContributorScore } from "./contributor-score";
 import { getCachedAuthorDossier, setCachedAuthorDossier } from "./repo-data-cache";
+import {
+	githubCacheKeyPart,
+	githubCacheKeys,
+	normalizeGithubRepoKey,
+} from "./github-cache-descriptors";
 import { isShareableCacheType, isSharedCacheReadEnabled } from "./github-cache-policy";
 
 export type RepoPermissions = {
@@ -228,24 +233,20 @@ function normalizeRef(ref?: string): string {
 	return value ? value : "";
 }
 
-function normalizePath(path: string): string {
-	return path.replace(/^\/+/, "").replace(/\/+$/, "");
-}
-
 function normalizeRepoKey(owner: string, repo: string): string {
-	return `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+	return normalizeGithubRepoKey(owner, repo);
 }
 
 function keyPart(value: string): string {
-	return encodeURIComponent(value === "" ? "~" : value);
+	return githubCacheKeyPart(value);
 }
 
 function buildUserReposCacheKey(sort: RepoSort, perPage: number): string {
-	return `user_repos:${sort}:${perPage}`;
+	return githubCacheKeys.userRepos(sort, perPage);
 }
 
 function buildRepoCacheKey(owner: string, repo: string): string {
-	return `repo:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repo(owner, repo);
 }
 
 function buildRepoContentsCacheKey(
@@ -254,9 +255,7 @@ function buildRepoContentsCacheKey(
 	path: string,
 	ref?: string,
 ): string {
-	return `repo_contents:${normalizeRepoKey(owner, repo)}:${keyPart(
-		normalizeRef(ref),
-	)}:${keyPart(normalizePath(path))}`;
+	return githubCacheKeys.repoContents(owner, repo, path, ref);
 }
 
 function buildRepoTreeCacheKey(
@@ -265,43 +264,39 @@ function buildRepoTreeCacheKey(
 	treeSha: string,
 	recursive: boolean,
 ): string {
-	return `repo_tree:${normalizeRepoKey(owner, repo)}:${keyPart(
-		treeSha,
-	)}:${recursive ? "1" : "0"}`;
+	return githubCacheKeys.repoTree(owner, repo, treeSha, recursive);
 }
 
 function buildRepoBranchesCacheKey(owner: string, repo: string): string {
-	return `repo_branches:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoBranches(owner, repo);
 }
 
 function buildRepoTagsCacheKey(owner: string, repo: string): string {
-	return `repo_tags:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoTags(owner, repo);
 }
 
 function buildRepoReleasesCacheKey(owner: string, repo: string): string {
-	return `repo_releases:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoReleases(owner, repo);
 }
 
 function buildFileContentCacheKey(owner: string, repo: string, path: string, ref?: string): string {
-	return `file_content:${normalizeRepoKey(owner, repo)}:${keyPart(
-		normalizeRef(ref),
-	)}:${keyPart(normalizePath(path))}`;
+	return githubCacheKeys.fileContent(owner, repo, path, ref);
 }
 
 function buildRepoReadmeCacheKey(owner: string, repo: string, ref?: string): string {
-	return `repo_readme:${normalizeRepoKey(owner, repo)}:${keyPart(normalizeRef(ref))}`;
+	return githubCacheKeys.repoReadme(owner, repo, ref);
 }
 
 function buildAuthenticatedUserCacheKey(): string {
-	return "authenticated_user";
+	return githubCacheKeys.authenticatedUser();
 }
 
 function buildUserOrgsCacheKey(perPage: number): string {
-	return `user_orgs:${perPage}`;
+	return githubCacheKeys.userOrgs(perPage);
 }
 
 function buildOrgCacheKey(org: string): string {
-	return `org:${org.toLowerCase()}`;
+	return githubCacheKeys.org(org);
 }
 
 function buildOrgReposCacheKey(
@@ -310,117 +305,117 @@ function buildOrgReposCacheKey(
 	type: OrgRepoType,
 	perPage: number,
 ): string {
-	return `org_repos:${org.toLowerCase()}:${sort}:${type}:${perPage}`;
+	return githubCacheKeys.orgRepos(org, sort, type, perPage);
 }
 
 function buildNotificationsCacheKey(perPage: number): string {
-	return `notifications:${perPage}`;
+	return githubCacheKeys.notifications(perPage);
 }
 
 function buildSearchIssuesCacheKey(query: string, perPage: number): string {
-	return `search_issues:${keyPart(query)}:${perPage}`;
+	return githubCacheKeys.searchIssues(query, perPage);
 }
 
 function buildUserEventsCacheKey(username: string, perPage: number): string {
-	return `user_events:${username.toLowerCase()}:${perPage}`;
+	return githubCacheKeys.userEvents(username, perPage);
 }
 
 function buildStarredReposCacheKey(perPage: number): string {
-	return `starred_repos:${perPage}`;
+	return githubCacheKeys.starredRepos(perPage);
 }
 
 function buildContributionsCacheKey(username: string): string {
-	return `contributions:v3:${username.toLowerCase()}`;
+	return githubCacheKeys.contributions(username);
 }
 
 function buildTrendingReposCacheKey(since: string, perPage: number, language?: string): string {
-	return `trending_repos:${since}:${perPage}:${keyPart(language ?? "")}`;
+	return githubCacheKeys.trendingRepos(since, perPage, language);
 }
 
 function buildRepoIssuesCacheKey(owner: string, repo: string, state: string): string {
-	return `repo_issues:${normalizeRepoKey(owner, repo)}:${state}`;
+	return githubCacheKeys.repoIssues(owner, repo, state);
 }
 
 function buildRepoPullRequestsCacheKey(owner: string, repo: string, state: string): string {
-	return `repo_pull_requests:${normalizeRepoKey(owner, repo)}:${state}`;
+	return githubCacheKeys.repoPullRequests(owner, repo, state);
 }
 
 function buildIssueCacheKey(owner: string, repo: string, issueNumber: number): string {
-	return `issue:${normalizeRepoKey(owner, repo)}:${issueNumber}`;
+	return githubCacheKeys.issue(owner, repo, issueNumber);
 }
 
 function buildIssueCommentsCacheKey(owner: string, repo: string, issueNumber: number): string {
-	return `issue_comments:${normalizeRepoKey(owner, repo)}:${issueNumber}`;
+	return githubCacheKeys.issueComments(owner, repo, issueNumber);
 }
 
 function buildPullRequestCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pull_request:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.pullRequest(owner, repo, pullNumber);
 }
 
 function buildPullRequestFilesCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pull_request_files:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.pullRequestFiles(owner, repo, pullNumber);
 }
 
 function buildPullRequestCommentsCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pull_request_comments:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.pullRequestComments(owner, repo, pullNumber);
 }
 
 function buildPullRequestReviewsCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pull_request_reviews:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.pullRequestReviews(owner, repo, pullNumber);
 }
 
 function buildPullRequestCommitsCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pull_request_commits:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.pullRequestCommits(owner, repo, pullNumber);
 }
 
 function buildRepoContributorsCacheKey(owner: string, repo: string, perPage: number): string {
-	return `repo_contributors:${normalizeRepoKey(owner, repo)}:${perPage}`;
+	return githubCacheKeys.repoContributors(owner, repo, perPage);
 }
 
 function buildUserProfileCacheKey(username: string): string {
-	return `user_profile:${username.toLowerCase()}`;
+	return githubCacheKeys.userProfile(username);
 }
 
 function buildUserPublicReposCacheKey(username: string, perPage: number): string {
-	return `user_public_repos:${username.toLowerCase()}:${perPage}`;
+	return githubCacheKeys.userPublicRepos(username, perPage);
 }
 
 function buildUserPublicOrgsCacheKey(username: string): string {
-	return `user_public_orgs:${username.toLowerCase()}`;
+	return githubCacheKeys.userPublicOrgs(username);
 }
 
 function buildRepoWorkflowsCacheKey(owner: string, repo: string): string {
-	return `repo_workflows:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoWorkflows(owner, repo);
 }
 
 function buildRepoWorkflowRunsCacheKey(owner: string, repo: string, perPage: number): string {
-	return `repo_workflow_runs:${normalizeRepoKey(owner, repo)}:${perPage}`;
+	return githubCacheKeys.repoWorkflowRuns(owner, repo, perPage);
 }
 
 function buildRepoNavCountsCacheKey(owner: string, repo: string): string {
-	return `repo_nav_counts:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoNavCounts(owner, repo);
 }
 
 function buildRepoLanguagesCacheKey(owner: string, repo: string): string {
-	return `repo_languages:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoLanguages(owner, repo);
 }
 
 function buildOrgMembersCacheKey(org: string, perPage: number): string {
-	return `org_members:${org.toLowerCase()}:${perPage}`;
+	return githubCacheKeys.orgMembers(org, perPage);
 }
 
 function buildPersonRepoActivityCacheKey(owner: string, repo: string, username: string): string {
-	return `person_repo_activity:${normalizeRepoKey(owner, repo)}:${username.toLowerCase()}`;
+	return githubCacheKeys.personRepoActivity(owner, repo, username);
 }
 
 function buildPRBundleCacheKey(owner: string, repo: string, pullNumber: number): string {
-	return `pr_bundle:${normalizeRepoKey(owner, repo)}:${pullNumber}`;
+	return githubCacheKeys.prBundle(owner, repo, pullNumber);
 }
 
 const DEFAULT_BRANCH_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
 function defaultBranchRedisKey(owner: string, repo: string): string {
-	return `repo_default_branch:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.defaultBranch(owner, repo);
 }
 
 export async function getCachedDefaultBranch(owner: string, repo: string): Promise<string | null> {
@@ -4583,7 +4578,7 @@ async function fetchDiscussionDetailGraphQL(
 // ── Discussion exported functions ──
 
 function buildRepoDiscussionsCacheKey(owner: string, repo: string): string {
-	return `repo_discussions:v2:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoDiscussions(owner, repo);
 }
 
 export async function getRepoDiscussionsPage(
@@ -5062,7 +5057,7 @@ export async function getRepoIssuesWithStats(
 }
 
 function buildRepoIssuesPageCacheKey(owner: string, repo: string): string {
-	return `repo_issues_page:${normalizeRepoKey(owner, repo)}`;
+	return githubCacheKeys.repoIssuesPage(owner, repo);
 }
 
 export async function getRepoIssuesPage(owner: string, repo: string): Promise<RepoIssuesPageData> {

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -1,7 +1,5 @@
 import { Octokit } from "@octokit/rest";
-import { headers } from "next/headers";
 import { cache } from "react";
-import { $Session, getServerSession } from "./auth";
 import {
 	claimDueGithubSyncJobs,
 	deleteGithubCacheByPrefix,
@@ -24,6 +22,7 @@ import {
 	githubCacheKeys,
 	normalizeGithubRepoKey,
 } from "./github-cache-descriptors";
+import { getRequestGitHubAuthContext, type GitHubAuthContext } from "./github-auth-context";
 import { isShareableCacheType, isSharedCacheReadEnabled } from "./github-cache-policy";
 
 export type RepoPermissions = {
@@ -50,14 +49,6 @@ export function extractRepoPermissions(repoData: {
 type RepoSort = "updated" | "pushed" | "full_name";
 type OrgRepoSort = "created" | "updated" | "pushed" | "full_name";
 type OrgRepoType = "all" | "public" | "private" | "forks" | "sources" | "member";
-
-interface GitHubAuthContext {
-	userId: string;
-	token: string;
-	octokit: Octokit;
-	forceRefresh: boolean;
-	githubUser: $Session["githubUser"];
-}
 
 type GitDataSyncJobType =
 	| "user_repos"
@@ -94,6 +85,7 @@ type GitDataSyncJobType =
 	| "user_public_orgs"
 	| "repo_workflows"
 	| "repo_workflow_runs"
+	| "repo_events"
 	| "repo_nav_counts"
 	| "org_members"
 	| "person_repo_activity"
@@ -134,6 +126,8 @@ interface LocalFirstGitReadOptions<T> {
 	jobPayload: GitDataSyncJobPayload;
 	fetchRemote: (octokit: Octokit) => Promise<T>;
 }
+
+type GitHubAuthOverride = GitHubAuthContext | null | undefined;
 
 const globalForGithubSync = globalThis as typeof globalThis & {
 	__githubSyncDrainingUsers?: Set<string>;
@@ -392,6 +386,10 @@ function buildRepoWorkflowRunsCacheKey(owner: string, repo: string, perPage: num
 	return githubCacheKeys.repoWorkflowRuns(owner, repo, perPage);
 }
 
+function buildRepoEventsCacheKey(owner: string, repo: string, perPage: number): string {
+	return githubCacheKeys.repoEvents(owner, repo, perPage);
+}
+
 function buildRepoNavCountsCacheKey(owner: string, repo: string): string {
 	return githubCacheKeys.repoNavCounts(owner, repo);
 }
@@ -428,27 +426,14 @@ async function cacheDefaultBranch(owner: string, repo: string, branch: string): 
 	});
 }
 
-const getGitHubAuthContext = cache(async (): Promise<GitHubAuthContext | null> => {
-	const session = await getServerSession();
-	const reqHeaders = await headers();
-	if (!session) return null;
-	const token = session.githubUser.accessToken;
+const getGitHubAuthContext = getRequestGitHubAuthContext;
 
-	const cacheControl = reqHeaders.get("cache-control") ?? "";
-	const pragma = reqHeaders.get("pragma") ?? "";
-	const forceRefresh =
-		cacheControl.includes("no-cache") ||
-		cacheControl.includes("max-age=0") ||
-		pragma.includes("no-cache");
-
-	return {
-		userId: session.user.id,
-		token,
-		octokit: new Octokit({ auth: token }),
-		forceRefresh,
-		githubUser: session.githubUser,
-	};
-});
+async function resolveGitHubAuthContext(
+	authOverride?: GitHubAuthOverride,
+): Promise<GitHubAuthContext | null> {
+	if (authOverride !== undefined) return authOverride;
+	return getGitHubAuthContext();
+}
 
 function getSyncErrorMessage(error: unknown): string {
 	if (typeof error === "object" && error !== null) {
@@ -2322,6 +2307,22 @@ async function processGitDataSyncJob(
 			);
 			return;
 		}
+		case "repo_events": {
+			const perPage = payload.perPage ?? 30;
+			const data = await fetchRepoEventsFromGitHub(
+				authCtx.octokit,
+				owner,
+				repo,
+				perPage,
+			);
+			await upsertGithubCacheEntry(
+				authCtx.userId,
+				buildRepoEventsCacheKey(owner, repo, perPage),
+				"repo_events",
+				data,
+			);
+			return;
+		}
 		case "repo_nav_counts": {
 			const openIssuesAndPrs = payload.openIssuesAndPrs ?? 0;
 			const data = await fetchRepoNavCountsFromGitHub(
@@ -2495,8 +2496,12 @@ export async function getAuthenticatedUser() {
 	return authCtx?.githubUser ?? null;
 }
 
-export async function getUserRepos(sort: RepoSort = "updated", perPage = 30) {
-	const authCtx = await getGitHubAuthContext();
+export async function getUserRepos(
+	sort: RepoSort = "updated",
+	perPage = 30,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const cacheKey = buildUserReposCacheKey(sort, perPage);
 
 	return readLocalFirstGitData({
@@ -2510,8 +2515,8 @@ export async function getUserRepos(sort: RepoSort = "updated", perPage = 30) {
 	});
 }
 
-export async function getUserOrgs(perPage = 50) {
-	const authCtx = await getGitHubAuthContext();
+export async function getUserOrgs(perPage = 50, authOverride?: GitHubAuthOverride) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildUserOrgsCacheKey(perPage),
@@ -2534,8 +2539,9 @@ export async function getOrgRepos(
 		sort?: OrgRepoSort;
 		type?: OrgRepoType;
 	} = {},
+	authOverride?: GitHubAuthOverride,
 ) {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildOrgReposCacheKey(org, sort, type, perPage),
@@ -2781,8 +2787,9 @@ export async function getRepoTree(
 	repo: string,
 	treeSha: string,
 	recursive?: boolean,
+	authOverride?: GitHubAuthOverride,
 ) {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const recursiveFlag = recursive === true;
 	const cacheKey = buildRepoTreeCacheKey(owner, repo, treeSha, recursiveFlag);
 
@@ -2798,8 +2805,12 @@ export async function getRepoTree(
 	});
 }
 
-export async function getRepoBranches(owner: string, repo: string) {
-	const authCtx = await getGitHubAuthContext();
+export async function getRepoBranches(
+	owner: string,
+	repo: string,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const cacheKey = buildRepoBranchesCacheKey(owner, repo);
 
 	return readLocalFirstGitData({
@@ -2813,8 +2824,8 @@ export async function getRepoBranches(owner: string, repo: string) {
 	});
 }
 
-export async function getRepoTags(owner: string, repo: string) {
-	const authCtx = await getGitHubAuthContext();
+export async function getRepoTags(owner: string, repo: string, authOverride?: GitHubAuthOverride) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const cacheKey = buildRepoTagsCacheKey(owner, repo);
 
 	return readLocalFirstGitData({
@@ -2828,8 +2839,12 @@ export async function getRepoTags(owner: string, repo: string) {
 	});
 }
 
-export async function getRepoReleases(owner: string, repo: string) {
-	const authCtx = await getGitHubAuthContext();
+export async function getRepoReleases(
+	owner: string,
+	repo: string,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const cacheKey = buildRepoReleasesCacheKey(owner, repo);
 
 	const releases = await readLocalFirstGitData({
@@ -2929,8 +2944,13 @@ export async function getFileContent(owner: string, repo: string, path: string, 
 	});
 }
 
-export async function getRepoReadme(owner: string, repo: string, ref?: string) {
-	const authCtx = await getGitHubAuthContext();
+export async function getRepoReadme(
+	owner: string,
+	repo: string,
+	ref?: string,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const normalizedRef = normalizeRef(ref);
 	const cacheKey = buildRepoReadmeCacheKey(owner, repo, normalizedRef);
 
@@ -4044,8 +4064,9 @@ export async function getRepoIssues(
 	owner: string,
 	repo: string,
 	state: "open" | "closed" | "all" = "open",
+	authOverride?: GitHubAuthOverride,
 ) {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildRepoIssuesCacheKey(owner, repo, state),
@@ -4584,8 +4605,9 @@ function buildRepoDiscussionsCacheKey(owner: string, repo: string): string {
 export async function getRepoDiscussionsPage(
 	owner: string,
 	repo: string,
+	authOverride?: GitHubAuthOverride,
 ): Promise<RepoDiscussionsPageData> {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	const fallback: RepoDiscussionsPageData = {
 		discussions: [],
 		totalCount: 0,
@@ -5202,8 +5224,9 @@ export async function getRepoPullRequests(
 	owner: string,
 	repo: string,
 	state: "open" | "closed" | "all" = "open",
+	authOverride?: GitHubAuthOverride,
 ) {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildRepoPullRequestsCacheKey(owner, repo, state),
@@ -6320,8 +6343,13 @@ export async function getRepoWorkflows(owner: string, repo: string) {
 	});
 }
 
-export async function getRepoWorkflowRuns(owner: string, repo: string, perPage = 50) {
-	const authCtx = await getGitHubAuthContext();
+export async function getRepoWorkflowRuns(
+	owner: string,
+	repo: string,
+	perPage = 50,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildRepoWorkflowRunsCacheKey(owner, repo, perPage),
@@ -6419,11 +6447,12 @@ export async function getRepoContributors(
 	owner: string,
 	repo: string,
 	perPage = 20,
+	authOverride?: GitHubAuthOverride,
 ): Promise<{
 	list: { login: string; avatar_url: string; contributions: number; html_url: string }[];
 	totalCount: number;
 }> {
-	const authCtx = await getGitHubAuthContext();
+	const authCtx = await resolveGitHubAuthContext(authOverride);
 	return readLocalFirstGitData({
 		authCtx,
 		cacheKey: buildRepoContributorsCacheKey(owner, repo, perPage),
@@ -6948,13 +6977,11 @@ export const getRepoPageData = cache(
 	},
 );
 
-export async function fetchAndCacheRepoPageData(
+export async function fetchAndCacheRepoPageDataWithAuth(
+	authCtx: GitHubAuthContext,
 	owner: string,
 	repo: string,
 ): Promise<RepoPageDataResult> {
-	const authCtx = await getGitHubAuthContext();
-	if (!authCtx) return { success: false, error: "Not authenticated" };
-
 	try {
 		const result = await fetchRepoPageDataGraphQL(authCtx.token, owner, repo);
 		if (!result) return { success: false, error: "Repository not found" };
@@ -6987,6 +7014,15 @@ export async function fetchAndCacheRepoPageData(
 	}
 }
 
+export async function fetchAndCacheRepoPageData(
+	owner: string,
+	repo: string,
+): Promise<RepoPageDataResult> {
+	const authCtx = await getGitHubAuthContext();
+	if (!authCtx) return { success: false, error: "Not authenticated" };
+	return fetchAndCacheRepoPageDataWithAuth(authCtx, owner, repo);
+}
+
 export async function getRepoOverviewData(
 	owner: string,
 	repo: string,
@@ -7003,21 +7039,36 @@ export async function getRepoOverviewData(
 	};
 }
 
-export async function getRepoEvents(owner: string, repo: string, perPage = 30) {
-	const octokit = await getOctokit();
-	if (!octokit) return [];
+export async function getRepoEvents(
+	owner: string,
+	repo: string,
+	perPage = 30,
+	authOverride?: GitHubAuthOverride,
+) {
+	const authCtx = await resolveGitHubAuthContext(authOverride);
+	return readLocalFirstGitData({
+		authCtx,
+		cacheKey: buildRepoEventsCacheKey(owner, repo, perPage),
+		cacheType: "repo_events",
+		fallback: [],
+		jobType: "repo_events",
+		jobPayload: { owner, repo, perPage },
+		fetchRemote: (octokit) => fetchRepoEventsFromGitHub(octokit, owner, repo, perPage),
+	});
+}
 
-	try {
-		const { data } = await octokit.activity.listRepoEvents({
-			owner,
-			repo,
-			per_page: perPage,
-		});
-		return data;
-	} catch (error) {
-		rethrowKnownGitHubErrors(error);
-		return [];
-	}
+async function fetchRepoEventsFromGitHub(
+	octokit: Octokit,
+	owner: string,
+	repo: string,
+	perPage: number,
+) {
+	const { data } = await octokit.activity.listRepoEvents({
+		owner,
+		repo,
+		per_page: perPage,
+	});
+	return data;
 }
 
 export interface PersonRepoActivity {

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -19,6 +19,7 @@ import {
 import { redis } from "./redis";
 import { computeContributorScore } from "./contributor-score";
 import { getCachedAuthorDossier, setCachedAuthorDossier } from "./repo-data-cache";
+import { isShareableCacheType, isSharedCacheReadEnabled } from "./github-cache-policy";
 
 export type RepoPermissions = {
 	admin: boolean;
@@ -94,40 +95,8 @@ type GitDataSyncJobType =
 	| "pr_bundle"
 	| "repo_discussions";
 
-// SECURITY: Only cache types that are safe to share across users belong here.
-// Any data from repos (issues, PRs, code, branches, etc.) is excluded because
-// private-repo data fetched by one authorized user would leak to others via
-// the shared cache, bypassing GitHub permission checks.
-// user_public_repos and org_repos are excluded: GitHub returns private repos when
-// the token matches the profile owner; see filterUserProfileReposForViewer.
-const SHAREABLE_CACHE_TYPES: ReadonlySet<string> = new Set([
-	"repo_branches",
-	"repo_tags",
-	"repo_releases",
-	"repo_issues",
-	"repo_pull_requests",
-	"issue",
-	"issue_comments",
-	"pull_request",
-	"pull_request_files",
-	"pull_request_comments",
-	"pull_request_reviews",
-	"pull_request_commits",
-	"repo_contributors",
-	"repo_workflows",
-	"repo_workflow_runs",
-	"repo_nav_counts",
-	"user_profile",
-	"user_public_orgs",
-	"user_events",
-	"org",
-	"org_members",
-	"trending_repos",
-]);
-
-function isShareableCacheType(jobType: string): boolean {
-	return SHAREABLE_CACHE_TYPES.has(jobType);
-}
+// SECURITY: Shared ghpub:* cache writes are allowlist-only in github-cache-policy.
+// Repo-scoped, org-scoped, and viewer-specific payloads must stay user-scoped.
 
 interface GitDataSyncJobPayload {
 	owner?: string;
@@ -2443,7 +2412,7 @@ async function enqueueGitDataSync(
 	cacheKey: string,
 	payload: GitDataSyncJobPayload,
 ) {
-	if (isShareableCacheType(jobType)) {
+	if (isShareableCacheType(jobType) && isSharedCacheReadEnabled()) {
 		const shared = await getSharedCacheEntry(cacheKey);
 		if (shared && Date.now() - new Date(shared.syncedAt).getTime() < 2 * 60 * 1000) {
 			return; // Another user recently refreshed this data
@@ -2485,8 +2454,9 @@ async function readLocalFirstGitData<T>({
 		return cached.data;
 	}
 
-	// Check shared cache before hitting GitHub API
-	if (shareable) {
+	// Check shared cache before hitting GitHub API. Disable with
+	// GITHUB_CACHE_SHARED_READ=0 during rollback/emergency response.
+	if (shareable && isSharedCacheReadEnabled()) {
 		const shared = await getSharedCacheEntry<T>(cacheKey);
 		if (shared) {
 			upsertGithubCacheEntry(

--- a/apps/web/src/lib/readme-cache.ts
+++ b/apps/web/src/lib/readme-cache.ts
@@ -1,7 +1,8 @@
 import { redis } from "./redis";
+import { githubCacheKeys } from "./github-cache-descriptors";
 
 function readmeKey(owner: string, repo: string): string {
-	return `readme_html:${owner.toLowerCase()}/${repo.toLowerCase()}`;
+	return githubCacheKeys.readmeHtml(owner, repo);
 }
 
 export async function getCachedReadmeHtml(owner: string, repo: string): Promise<string | null> {

--- a/apps/web/src/lib/repo-data-cache.ts
+++ b/apps/web/src/lib/repo-data-cache.ts
@@ -1,4 +1,5 @@
 import { redis } from "./redis";
+import { githubCacheKeys } from "./github-cache-descriptors";
 
 /** TTLs in seconds */
 const TTL = {
@@ -14,12 +15,8 @@ function repoKey(owner: string, repo: string, suffix: string): string {
 	return `${suffix}:${owner.toLowerCase()}/${repo.toLowerCase()}`;
 }
 
-function userRepoKey(userId: string, owner: string, repo: string, suffix: string): string {
-	return `${suffix}:${userId}:${owner.toLowerCase()}/${repo.toLowerCase()}`;
-}
-
 function languagesKey(owner: string, repo: string): string {
-	return repoKey(owner, repo, "repo_languages");
+	return githubCacheKeys.repoLanguages(owner, repo);
 }
 
 function contributorAvatarsKey(owner: string, repo: string): string {
@@ -27,11 +24,11 @@ function contributorAvatarsKey(owner: string, repo: string): string {
 }
 
 function branchesKey(owner: string, repo: string): string {
-	return repoKey(owner, repo, "repo_branches");
+	return githubCacheKeys.repoBranches(owner, repo);
 }
 
 function tagsKey(owner: string, repo: string): string {
-	return repoKey(owner, repo, "repo_tags");
+	return githubCacheKeys.repoTags(owner, repo);
 }
 
 export async function getCachedRepoLanguages(
@@ -110,7 +107,7 @@ export async function getCachedRepoPageData<T>(
 	owner: string,
 	repo: string,
 ): Promise<T | null> {
-	return redis.get<T>(userRepoKey(userId, owner, repo, "repo_page_data"));
+	return redis.get<T>(githubCacheKeys.repoPageData(userId, owner, repo));
 }
 
 export async function setCachedRepoPageData<T>(
@@ -119,7 +116,7 @@ export async function setCachedRepoPageData<T>(
 	repo: string,
 	data: T,
 ): Promise<void> {
-	await redis.set(userRepoKey(userId, owner, repo, "repo_page_data"), data, {
+	await redis.set(githubCacheKeys.repoPageData(userId, owner, repo), data, {
 		ex: TTL.medium,
 	});
 }
@@ -130,7 +127,7 @@ export async function updateCachedRepoPageDataNavCounts(
 	repo: string,
 	updates: { openPrs?: number; openIssues?: number },
 ): Promise<void> {
-	const key = userRepoKey(userId, owner, repo, "repo_page_data");
+	const key = githubCacheKeys.repoPageData(userId, owner, repo);
 	const existing = await redis.get<{
 		navCounts?: { openPrs: number; openIssues: number; activeRuns: number };
 	}>(key);
@@ -146,17 +143,17 @@ export async function updateCachedRepoPageDataNavCounts(
 }
 
 export async function getCachedRepoTree<T>(owner: string, repo: string): Promise<T | null> {
-	return redis.get<T>(repoKey(owner, repo, "repo_file_tree"));
+	return redis.get<T>(githubCacheKeys.repoFileTree(owner, repo));
 }
 
 export async function setCachedRepoTree<T>(owner: string, repo: string, tree: T): Promise<void> {
-	await redis.set(repoKey(owner, repo, "repo_file_tree"), tree, { ex: TTL.medium });
+	await redis.set(githubCacheKeys.repoFileTree(owner, repo), tree, { ex: TTL.medium });
 }
 
 // --- Overview caches (shared across all viewers) ---
 
 export async function getCachedOverviewPRs<T>(owner: string, repo: string): Promise<T[] | null> {
-	return redis.get<T[]>(repoKey(owner, repo, "overview_prs"));
+	return redis.get<T[]>(githubCacheKeys.overviewPRs(owner, repo));
 }
 
 export async function setCachedOverviewPRs<T>(
@@ -164,11 +161,11 @@ export async function setCachedOverviewPRs<T>(
 	repo: string,
 	data: T[],
 ): Promise<void> {
-	await redis.set(repoKey(owner, repo, "overview_prs"), data, { ex: TTL.fast });
+	await redis.set(githubCacheKeys.overviewPRs(owner, repo), data, { ex: TTL.fast });
 }
 
 export async function getCachedOverviewIssues<T>(owner: string, repo: string): Promise<T[] | null> {
-	return redis.get<T[]>(repoKey(owner, repo, "overview_issues"));
+	return redis.get<T[]>(githubCacheKeys.overviewIssues(owner, repo));
 }
 
 export async function setCachedOverviewIssues<T>(
@@ -176,11 +173,11 @@ export async function setCachedOverviewIssues<T>(
 	repo: string,
 	data: T[],
 ): Promise<void> {
-	await redis.set(repoKey(owner, repo, "overview_issues"), data, { ex: TTL.fast });
+	await redis.set(githubCacheKeys.overviewIssues(owner, repo), data, { ex: TTL.fast });
 }
 
 export async function getCachedOverviewEvents<T>(owner: string, repo: string): Promise<T[] | null> {
-	return redis.get<T[]>(repoKey(owner, repo, "overview_events"));
+	return redis.get<T[]>(githubCacheKeys.overviewEvents(owner, repo));
 }
 
 export async function setCachedOverviewEvents<T>(
@@ -188,14 +185,14 @@ export async function setCachedOverviewEvents<T>(
 	repo: string,
 	data: T[],
 ): Promise<void> {
-	await redis.set(repoKey(owner, repo, "overview_events"), data, { ex: TTL.fast });
+	await redis.set(githubCacheKeys.overviewEvents(owner, repo), data, { ex: TTL.fast });
 }
 
 export async function getCachedOverviewCommitActivity<T>(
 	owner: string,
 	repo: string,
 ): Promise<T[] | null> {
-	return redis.get<T[]>(repoKey(owner, repo, "overview_commit_activity"));
+	return redis.get<T[]>(githubCacheKeys.overviewCommitActivity(owner, repo));
 }
 
 export async function setCachedOverviewCommitActivity<T>(
@@ -203,15 +200,17 @@ export async function setCachedOverviewCommitActivity<T>(
 	repo: string,
 	data: T[],
 ): Promise<void> {
-	await redis.set(repoKey(owner, repo, "overview_commit_activity"), data, { ex: TTL.fast });
+	await redis.set(githubCacheKeys.overviewCommitActivity(owner, repo), data, {
+		ex: TTL.fast,
+	});
 }
 
 export async function getCachedOverviewCI<T>(owner: string, repo: string): Promise<T | null> {
-	return redis.get<T>(repoKey(owner, repo, "overview_ci"));
+	return redis.get<T>(githubCacheKeys.overviewCI(owner, repo));
 }
 
 export async function setCachedOverviewCI<T>(owner: string, repo: string, data: T): Promise<void> {
-	await redis.set(repoKey(owner, repo, "overview_ci"), data, { ex: TTL.fast });
+	await redis.set(githubCacheKeys.overviewCI(owner, repo), data, { ex: TTL.fast });
 }
 
 // --- Author dossier cache (per author per repo) ---


### PR DESCRIPTION
## Summary\n\n- restrict shared GitHub cache reads to explicitly shareable public metadata\n- add typed GitHub cache descriptors, freshness policy, and cache-key builders\n- revive failed GitHub sync jobs instead of letting failed dedupe rows block future refreshes\n- extract reusable GitHub auth context resolution for request and user-scoped worker paths\n- move repo events onto the local-first cache/sync path\n\n## Validation\n\n- bun run typecheck\n- bun run --workspaces typecheck\n- bun run lint\n- apps/web vitest: 6 files / 49 tests passing\n\n## Notes\n\n- Phase 4+ was intentionally not started.\n- No Inngest worker entrypoint existed in this checkout, so Phase 3 exports the worker-ready auth helpers without wiring a missing worker surface.\n